### PR TITLE
Create `wp config path` to get the path to `wp-config.php` file

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -1,0 +1,11 @@
+Feature: Manage wp-config.php file
+
+  Scenario: Get a wp-config.php file path
+    Given a WP install
+
+    When I try `wp config path`
+    And STDOUT should contain:
+      """
+      wp-config.php
+      """
+    And STDERR should be empty

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -149,6 +149,22 @@ class Config_Command extends WP_CLI_Command {
 		}
 	}
 
+	/**
+	 * Get the path to wp-config.php file.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get wp-config.php file path
+	 *     $ wp config path
+	 *     /home/person/htdocs/project/wp-config.php
+	 */
+	public function path() {
+		$path = Utils\locate_wp_config();
+		if ( $path ) {
+			WP_CLI::line( $path );
+		}
+	}
+
 	private static function _read( $url ) {
 		$headers = array('Accept' => 'application/json');
 		$response = Utils\http_request( 'GET', $url, null, $headers, array( 'timeout' => 30 ) );


### PR DESCRIPTION
No need to add an error message if `wp-config.php` file is not found, as `Runner::start` method will take care of the error.

Fixes #5 