### PR TITLE
Create `wp config get` to list configurations of `wp-config.php`

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -1,11 +1,25 @@
 Feature: Manage wp-config.php file
 
-  Scenario: Get a wp-config.php file path
+  Background:
     Given a WP install
 
+  Scenario: Get a wp-config.php file path
     When I try `wp config path`
     And STDOUT should contain:
       """
       wp-config.php
       """
     And STDERR should be empty
+
+  Scenario: Get configurations defined in a wp-config.php file
+    When I try `wp config get`
+    Then STDOUT should be a table containing rows:
+      | key | value | type |
+
+    When I try `wp config get --fields=key,type`
+    Then STDOUT should be a table containing rows:
+      | key         | type     |
+      | DB_NAME     | constant |
+      | DB_USER     | constant |
+      | DB_PASSWORD | constant |
+      | DB_HOST     | constant |

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -208,7 +208,6 @@ class Config_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function get( $_, $assoc_args ) {
-
 		$default_fields = array(
 			'key',
 			'value',
@@ -242,8 +241,8 @@ class Config_Command extends WP_CLI_Command {
 	/**
 	 * Filter wp-config.php file configurations.
 	 *
-	 * @param $list
-	 * @param $previous_list
+	 * @param array $list
+	 * @param array $previous_list
 	 * @param array $exclude_list
 	 * @return array
 	 */


### PR DESCRIPTION
We can also format the result using `--format` option.
eg. `wp config get --format=csv`

Fixes #2