### PR TITLE
Make the config command consistent by provideing "list" and "get".

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -11,15 +11,27 @@ Feature: Manage wp-config.php file
       """
     And STDERR should be empty
 
-  Scenario: Get configurations defined in a wp-config.php file
-    When I try `wp config get`
+  Scenario: List configurations defined in a wp-config.php file
+    When I try `wp config list`
     Then STDOUT should be a table containing rows:
       | key | value | type |
 
-    When I try `wp config get --fields=key,type`
+    When I try `wp config list --fields=key,type`
     Then STDOUT should be a table containing rows:
       | key         | type     |
       | DB_NAME     | constant |
       | DB_USER     | constant |
       | DB_PASSWORD | constant |
       | DB_HOST     | constant |
+
+  Scenario: Get a specific value as defined in a wp-config.php file
+    When I try `wp config get table_prefix`
+    Then STDOUT should be:
+      """
+      wp_
+      """
+    And STDERR should be empty
+
+    When I try `wp config get non-existent-key`
+    Then STDOUT should be empty
+    And the return code should be 1


### PR DESCRIPTION
To make the `wp config` command more consistent with the way the rest of the commands behave, and to add needed functionality, I renamed the current `wp config get` command (which displays a list of all values) into `wp config list`, and added a new `wp config get <key>` command to retrieve the value of a specific key.

This allows one to use something like `wp config get table_prefix` to quickly get one particular value.