### PR TITLE
add first version of constant and global getting code

### DIFF
--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -1,0 +1,84 @@
+Feature: Get the value of a constant or global defined in wp-config.php file
+
+  Background:
+    Given a WP install
+
+  Scenario: Get the value of an existing wp-config.php constant
+    When I try `wp config get --constant=DB_NAME`
+    And STDOUT should be:
+      """
+      wp_cli_test
+      """
+    And STDERR should be empty
+
+  Scenario: Get the value of an existing wp-config.php global
+    When I try `wp config get --global=table_prefix`
+    And STDOUT should be:
+      """
+      wp_
+      """
+    And STDERR should be empty
+
+  Scenario: Get the value of a non existing wp-config.php constant
+    When I try `wp config get --constant=FOO`
+    And STDERR should be:
+      """
+      Error: the FOO constant is not defined in the wp-config.php file.
+      """
+    And STDOUT should be empty
+
+  Scenario: Get the value of a non existing wp-config.php global
+    When I try `wp config get --global=foo`
+    And STDERR should be:
+      """
+      Error: the foo global is not defined in the wp-config.php file.
+      """
+    And STDOUT should be empty
+
+  Scenario: Get the value of an existing wp-config.php constant with wrong case should yield an error
+    When I try `wp config get --constant=db_name`
+    And STDERR should be:
+      """
+      Error: the db_name constant is not defined in the wp-config.php file.
+      """
+    And STDOUT should be empty
+
+  Scenario: Get the value of an existing wp-config.php global with wrong case should yield an error
+    When I try `wp config get --global=TABLE_PREFIX`
+    And STDERR should be:
+      """
+      Error: the TABLE_PREFIX global is not defined in the wp-config.php file.
+      """
+    And STDOUT should be empty
+
+  Scenario: Get the value of an existing wp-config.php constant with some similarity should yield an helpful error
+    When I try `wp config get --constant=DB_NOME`
+    And STDERR should be:
+      """
+      Error: the DB_NOME constant is not defined in the wp-config.php file; were you looking for DB_NAME?
+      """
+    And STDOUT should be empty
+
+  Scenario: Get the value of an existing wp-config.php constant with some similarity should yield an helpful error
+    When I try `wp config get --global=table_perfix`
+    And STDERR should be:
+      """
+      Error: the table_perfix global is not defined in the wp-config.php file; were you looking for table_prefix?
+      """
+    And STDOUT should be empty
+
+  Scenario: Get the value of an existing wp-config.php constant with remote similarity should yield just an error
+    When I try `wp config get --constant=DB_NOOOOZLE`
+    And STDERR should be:
+      """
+      Error: the DB_NOOOOZLE constant is not defined in the wp-config.php file.
+      """
+    And STDOUT should be empty
+
+  Scenario: Get the value of an existing wp-config.php global with remote similarity should yield just an error
+    When I try `wp config get --global=tabre_peffix`
+    And STDERR should be:
+      """
+      Error: the tabre_peffix global is not defined in the wp-config.php file.
+      """
+    And STDOUT should be empty

--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -82,3 +82,11 @@ Feature: Get the value of a constant or global defined in wp-config.php file
       Error: the tabre_peffix global is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
+
+  Scenario: Trying to get the value of a constant and a global should yield an error
+    When I try `wp config get --constant=DB_NAME --global=table_prefix`
+    Then STDERR should be:
+      """
+      Error: cannot request the value of a constant and a global at the same time.
+      """
+    And STDOUT should be empty

--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -5,7 +5,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
 
   Scenario: Get the value of an existing wp-config.php constant
     When I try `wp config get --constant=DB_NAME`
-    And STDOUT should be:
+    Then STDOUT should be:
       """
       wp_cli_test
       """
@@ -13,7 +13,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
 
   Scenario: Get the value of an existing wp-config.php global
     When I try `wp config get --global=table_prefix`
-    And STDOUT should be:
+    Then STDOUT should be:
       """
       wp_
       """
@@ -21,7 +21,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
 
   Scenario: Get the value of a non existing wp-config.php constant
     When I try `wp config get --constant=FOO`
-    And STDERR should be:
+    Then STDERR should be:
       """
       Error: the FOO constant is not defined in the wp-config.php file.
       """
@@ -29,7 +29,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
 
   Scenario: Get the value of a non existing wp-config.php global
     When I try `wp config get --global=foo`
-    And STDERR should be:
+    Then STDERR should be:
       """
       Error: the foo global is not defined in the wp-config.php file.
       """
@@ -37,7 +37,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
 
   Scenario: Get the value of an existing wp-config.php constant with wrong case should yield an error
     When I try `wp config get --constant=db_name`
-    And STDERR should be:
+    Then STDERR should be:
       """
       Error: the db_name constant is not defined in the wp-config.php file.
       """
@@ -45,23 +45,23 @@ Feature: Get the value of a constant or global defined in wp-config.php file
 
   Scenario: Get the value of an existing wp-config.php global with wrong case should yield an error
     When I try `wp config get --global=TABLE_PREFIX`
-    And STDERR should be:
+    Then STDERR should be:
       """
       Error: the TABLE_PREFIX global is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
-  Scenario: Get the value of an existing wp-config.php constant with some similarity should yield an helpful error
+  Scenario: Get the value of an existing wp-config.php constant with some similarity should yield a helpful error
     When I try `wp config get --constant=DB_NOME`
-    And STDERR should be:
+    Then STDERR should be:
       """
       Error: the DB_NOME constant is not defined in the wp-config.php file; were you looking for DB_NAME?
       """
     And STDOUT should be empty
 
-  Scenario: Get the value of an existing wp-config.php constant with some similarity should yield an helpful error
+  Scenario: Get the value of an existing wp-config.php constant with some similarity should yield a helpful error
     When I try `wp config get --global=table_perfix`
-    And STDERR should be:
+    Then STDERR should be:
       """
       Error: the table_perfix global is not defined in the wp-config.php file; were you looking for table_prefix?
       """
@@ -69,7 +69,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
 
   Scenario: Get the value of an existing wp-config.php constant with remote similarity should yield just an error
     When I try `wp config get --constant=DB_NOOOOZLE`
-    And STDERR should be:
+    Then STDERR should be:
       """
       Error: the DB_NOOOOZLE constant is not defined in the wp-config.php file.
       """
@@ -77,7 +77,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
 
   Scenario: Get the value of an existing wp-config.php global with remote similarity should yield just an error
     When I try `wp config get --global=tabre_peffix`
-    And STDERR should be:
+    Then STDERR should be:
       """
       Error: the tabre_peffix global is not defined in the wp-config.php file.
       """

--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -23,7 +23,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --constant=FOO`
     Then STDERR should be:
       """
-      Error: the FOO constant is not defined in the wp-config.php file.
+      Error: The 'FOO' constant is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
@@ -31,7 +31,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --global=foo`
     Then STDERR should be:
       """
-      Error: the foo global is not defined in the wp-config.php file.
+      Error: The 'foo' global is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
@@ -39,7 +39,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --constant=db_name`
     Then STDERR should be:
       """
-      Error: the db_name constant is not defined in the wp-config.php file.
+      Error: The 'db_name' constant is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
@@ -47,7 +47,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --global=TABLE_PREFIX`
     Then STDERR should be:
       """
-      Error: the TABLE_PREFIX global is not defined in the wp-config.php file.
+      Error: The 'TABLE_PREFIX' global is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
@@ -55,7 +55,8 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --constant=DB_NOME`
     Then STDERR should be:
       """
-      Error: the DB_NOME constant is not defined in the wp-config.php file; were you looking for DB_NAME?
+      Error: The 'DB_NOME' constant is not defined in the wp-config.php file.
+      Did you mean 'DB_NAME'?
       """
     And STDOUT should be empty
 
@@ -63,7 +64,8 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --global=table_perfix`
     Then STDERR should be:
       """
-      Error: the table_perfix global is not defined in the wp-config.php file; were you looking for table_prefix?
+      Error: The 'table_perfix' global is not defined in the wp-config.php file.
+      Did you mean 'table_prefix'?
       """
     And STDOUT should be empty
 
@@ -71,7 +73,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --constant=DB_NOOOOZLE`
     Then STDERR should be:
       """
-      Error: the DB_NOOOOZLE constant is not defined in the wp-config.php file.
+      Error: The 'DB_NOOOOZLE' constant is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
@@ -79,7 +81,7 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --global=tabre_peffix`
     Then STDERR should be:
       """
-      Error: the tabre_peffix global is not defined in the wp-config.php file.
+      Error: The 'tabre_peffix' global is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
@@ -87,6 +89,6 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     When I try `wp config get --constant=DB_NAME --global=table_prefix`
     Then STDERR should be:
       """
-      Error: cannot request the value of a constant and a global at the same time.
+      Error: Cannot request the value of a constant and a global at the same time.
       """
     And STDOUT should be empty

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -234,7 +234,7 @@ class Config_Command extends WP_CLI_Command {
 		$get_global          = ! empty( $assoc_args['global'] );
 
 		if ( $get_constant && $get_global ) {
-			WP_CLI::error( 'cannot request the value of a constant and a global at the same time.' );
+			WP_CLI::error( 'Cannot request the value of a constant and a global at the same time.' );
 		}
 
 		if ( $get_constant || $get_global ) {
@@ -314,9 +314,9 @@ class Config_Command extends WP_CLI_Command {
 		$candidate = Utils\get_suggestion( $key, $keys );
 
 		if ( empty( $candidate ) ) {
-			WP_CLI::error( "the {$key} {$type} is not defined in the wp-config.php file." );
+			WP_CLI::error( "The '{$key}' {$type} is not defined in the wp-config.php file." );
 		} elseif ( $candidate !== $key ) {
-			WP_CLI::error( "the {$key} {$type} is not defined in the wp-config.php file; were you looking for {$candidate}?" );
+			WP_CLI::error( "The '{$key}' {$type} is not defined in the wp-config.php file.\nDid you mean '{$candidate}'?" );
 		}
 
 		return $look_into[ $candidate ];


### PR DESCRIPTION
Implements the feature of [#15](https://github.com/wp-cli/config-command/issues/15).

I've put in place a way to know if the user mistype a legit constant or global: in that case an error will be shown; I could use some feedback about that.