### PR TITLE
Generate keys/salts, use API as fallback

### DIFF
--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -127,10 +127,22 @@ class Config_Command extends WP_CLI_Command {
 			$assoc_args['extra-php'] = file_get_contents( 'php://stdin' );
 		}
 
-		// TODO: adapt more resilient code from wp-admin/setup-config.php
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-salts' ) ) {
-			$assoc_args['keys-and-salts'] = self::_read(
-				'https://api.wordpress.org/secret-key/1.1/salt/' );
+			try {
+				$assoc_args['keys-and-salts'] = true;
+				$assoc_args['auth-key'] = self::unique_key();
+				$assoc_args['secure-auth-key'] = self::unique_key();
+				$assoc_args['logged-in-key'] = self::unique_key();
+				$assoc_args['nonce-key'] = self::unique_key();
+				$assoc_args['auth-salt'] = self::unique_key();
+				$assoc_args['secure-auth-salt'] = self::unique_key();
+				$assoc_args['logged-in-salt'] = self::unique_key();
+				$assoc_args['nonce-salt'] = self::unique_key();
+			} catch ( Exception $e ) {
+				$assoc_args['keys-and-salts'] = false;
+				$assoc_args['keys-and-salts-alt'] = self::_read(
+					'https://api.wordpress.org/secret-key/1.1/salt/' );
+			}
 		}
 
 		if ( \WP_CLI\Utils\wp_version_compare( '4.0', '<' ) ) {
@@ -349,6 +361,22 @@ class Config_Command extends WP_CLI_Command {
 		}
 
 		return $look_into[ $candidate ];
+	}
+
+	/**
+	 * Generate a unique key/salt for the wp-config.php file.
+	 *
+	 * @return string
+	 */
+	private static function unique_key() {
+		$chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_ []{}<>~`+=,.;:/?|';
+		$key = '';
+
+		for ( $i = 0; $i < 64; $i++ ) {
+			$key .= substr( $chars, random_int( 0, strlen( $chars ) - 1 ), 1 );
+		}
+
+		return $key;
 	}
 }
 

--- a/templates/wp-config.mustache
+++ b/templates/wp-config.mustache
@@ -47,9 +47,16 @@ define( 'DB_COLLATE', '{{dbcollate}}' );
  * @since 2.6.0
  */
 {{#keys-and-salts}}
-{{keys-and-salts}}
+define( 'AUTH_KEY',         '{{auth-key}}' );
+define( 'SECURE_AUTH_KEY',  '{{secure-auth-key}}' );
+define( 'LOGGED_IN_KEY',    '{{logged-in-key}}' );
+define( 'NONCE_KEY',        '{{nonce-key}}' );
+define( 'AUTH_SALT',        '{{auth-salt}}' );
+define( 'SECURE_AUTH_SALT', '{{secure-auth-salt}}' );
+define( 'LOGGED_IN_SALT',   '{{logged-in-salt}}' );
+define( 'NONCE_SALT',       '{{nonce-salt}}' );
 {{/keys-and-salts}}
-
+{{keys-and-salts-alt}}
 /**
  * WordPress Database Table prefix.
  *


### PR DESCRIPTION
Rather than using the WordPress.org for key/salt generation by default, it should be used as a fallback only when [`random_int()`](https://secure.php.net/manual/en/function.random-int.php) (introduced in PHP 7) isn't available.

Relying on an external service here just creates a network bottleneck, that depending on your needs, affecting provisioning workflows.

In addition, using `--extra-php` is a little annoying because that placeholder in the mustache template is not able to insert keys/salts under the big commented area where they belong.

Here were the averages I came up with after running each 5 times:

### The HTTP request way
0.14s user 0.05s system 28% cpu 0.732 total

### The Generate way
0.11s user 0.04s system 81% cpu 0.183 total

Obviously CPU goes up since we're crunching cryptographically-secure random numbers, but the total time difference is quite drastic at 500ms or more. Precious provisioning time :-)