### PR TITLE
Define constants programmatically

### DIFF
--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -244,7 +244,7 @@ class Config_Command extends WP_CLI_Command {
 				$match = preg_replace( $pattern, $replace, $match );
 			}
 			$configs = implode( PHP_EOL, array_replace( $lines, $matches ) );
-		} elseif ( $add ) {
+		} elseif ( ! $matches && $add ) {
 			$search  = PHP_EOL . "/* That's all, stop editing! Happy blogging. */";
 			$configs = str_replace( $search, $replace . PHP_EOL . $search, $configs );
 		}

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -163,6 +163,102 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Define a constant in the wp-config.php file.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<name>]
+	 * : The constant name to be defined.
+	 *
+	 * [<value>]
+	 * : The constant value to be defined.
+	 *
+	 * [--add]
+	 * : Add definition if it doesn't exist. Default: true
+	 *
+	 * [--update]
+	 * : Update definition if it already exists. Default: true
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Boolean value.
+	 *     $ wp config define WP_DEBUG true --no-update
+	 *     Success: Defined constant 'WP_DEBUG' in wp-config.php.
+	 *
+	 *     # Only update an existing definition.
+	 *     $ wp config define WP_DEBUG true --no-add
+	 *     Success: Defined constant 'WP_DEBUG' in wp-config.php.
+	 *
+	 *     # Don't update existing definitions, only add new ones.
+	 *     $ wp config define WP_DEBUG true --no-update
+	 *     Success: Defined constant 'WP_DEBUG' in wp-config.php.
+	 *
+	 *     $ Integer value.
+	 *     $ wp config define WP_POST_REVISIONS 10
+	 *     Success: Defined constant 'WP_POST_REVISIONS' in wp-config.php.
+	 *
+	 *     $ Float value.
+	 *     $ wp config define MMMM_PIE 3.14
+	 *     Success: Defined constant 'MMMM_PIE' in wp-config.php.
+	 *
+	 *     $ String value.
+	 *     $ wp config define DB_NAME wordpress
+	 *     Success: Defined constant 'DB_HOST' in wp-config.php.
+	 *
+	 *     $ Array value.
+	 *     $ wp config define FOO_ARRAY "array( 'foo' => 'bar' )"
+	 *     Success: Defined constant 'FOO_ARRAY' in wp-config.php.
+	 *
+	 * @when before_wp_load
+	 */
+	public function define( $args, $assoc_args ) {
+		$add    = WP_CLI\Utils\get_flag_value( $assoc_args, 'add', true );
+		$update = WP_CLI\Utils\get_flag_value( $assoc_args, 'update', true );
+
+		if ( ! $add && ! $update ) {
+			WP_CLI::error( "'--no-add' and '--no-update' can't be used together." );
+		}
+
+		$name  = strtoupper( $args[0] );
+		$value = $args[1];
+
+		switch ( true ) {
+			case ( 'true' === strtolower( $value ) || 'false' === strtolower( $value ) ) :
+				$value = strtolower( $value );
+				break;
+			case preg_match( '/^(?:array\(|\[).*(?:\]|\))$/i', $value ) :
+				break;
+			case ! is_numeric( $value ) :
+				$value = sprintf( "'%s'", addcslashes( $value, "'\\" ) );
+				break;
+		}
+
+		$pattern = sprintf( '/^define\(.*[\'"]%s[\'"].*\)\s*;?/i', preg_quote( $name ) );
+		$replace = sprintf( "define( '%s', %s );", $name, $value );
+		$configs = file_get_contents( Utils\locate_wp_config() );
+		$lines   = explode( PHP_EOL, $configs );
+		$matches = preg_grep( $pattern, $lines );
+
+		if ( $matches && $update ) {
+			foreach ( $matches as &$match ) {
+				$match = preg_replace( $pattern, $replace, $match );
+			}
+			$configs = implode( PHP_EOL, array_replace( $lines, $matches ) );
+		} elseif ( $add ) {
+			$search  = PHP_EOL . "/* That's all, stop editing! Happy blogging. */";
+			$configs = str_replace( $search, $replace . PHP_EOL . $search, $configs );
+		}
+
+		$result = file_put_contents( Utils\locate_wp_config(), $configs, LOCK_EX );
+
+		if ( ! $result ) {
+			WP_CLI::error( 'wp-config.php file could not be updated.' );
+		}
+
+		WP_CLI::success( sprintf( "Defined constant '%s' in wp-config.php.", $name ) );
+	}
+
+	/**
 	 * Get the path to wp-config.php file.
 	 *
 	 * ## EXAMPLES

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -250,11 +250,10 @@ class Config_Command extends WP_CLI_Command {
 			$changes = str_replace( $search, $replace . PHP_EOL . $search, $configs );
 		}
 
-		if ( $changes === $configs ) {
+		$result = ( $changes === $configs ) ? 0 : file_put_contents( Utils\locate_wp_config(), $changes, LOCK_EX );
+
+		if ( 0 === $result ) {
 			WP_CLI::warning( 'No changes detected.' );
-			$result = 0;
-		} else {
-			$result = file_put_contents( Utils\locate_wp_config(), $changes, LOCK_EX );
 		}
 
 		if ( false === $result ) {

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -238,20 +238,26 @@ class Config_Command extends WP_CLI_Command {
 		$configs = file_get_contents( Utils\locate_wp_config() );
 		$lines   = explode( PHP_EOL, $configs );
 		$matches = preg_grep( $pattern, $lines );
+		$changes = '';
 
 		if ( $matches && $update ) {
 			foreach ( $matches as &$match ) {
 				$match = preg_replace( $pattern, $replace, $match );
 			}
-			$configs = implode( PHP_EOL, array_replace( $lines, $matches ) );
+			$changes = implode( PHP_EOL, array_replace( $lines, $matches ) );
 		} elseif ( ! $matches && $add ) {
 			$search  = PHP_EOL . "/* That's all, stop editing! Happy blogging. */";
-			$configs = str_replace( $search, $replace . PHP_EOL . $search, $configs );
+			$changes = str_replace( $search, $replace . PHP_EOL . $search, $configs );
 		}
 
-		$result = file_put_contents( Utils\locate_wp_config(), $configs, LOCK_EX );
+		if ( $changes === $configs ) {
+			WP_CLI::warning( 'No changes detected.' );
+			$result = 0;
+		} else {
+			$result = file_put_contents( Utils\locate_wp_config(), $changes, LOCK_EX );
+		}
 
-		if ( ! $result ) {
+		if ( false === $result ) {
 			WP_CLI::error( 'wp-config.php file could not be updated.' );
 		}
 


### PR DESCRIPTION
This is a partial implementation of https://github.com/wp-cli/ideas/issues/4. It doesn't include any tests (yet), or the ability to update variables - though I'm beginning to wonder if that should really be in the same command?

Anyhow, I'm not really sold on the `wp config define` semantics here. Mostly just want to see what others think of this direction and get some feedback. I needed this for myself and thought I'd post up here what I had come up with so far.