### PR TITLE
Convert config help summaries to use third-person singular verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package implements the following commands:
 
 ### wp config
 
-Manage the wp-config.php file
+Creates and retrieves the wp-config.php file.
 
 ~~~
 wp config
@@ -25,7 +25,7 @@ wp config
 
 ### wp config create
 
-Generate a wp-config.php file.
+Generates a wp-config.php file.
 
 ~~~
 wp config create --dbname=<dbname> --dbuser=<dbuser> [--dbpass=<dbpass>] [--dbhost=<dbhost>] [--dbprefix=<dbprefix>] [--dbcharset=<dbcharset>] [--dbcollate=<dbcollate>] [--locale=<locale>] [--extra-php] [--skip-salts] [--skip-check] [--force]
@@ -106,7 +106,7 @@ the database constants are correct.
 
 ### wp config get
 
-Get variables, constants, and file includes defined in wp-config.php file.
+Gets variables, constants, and file includes defined in wp-config.php file.
 
 ~~~
 wp config get [--fields=<fields>] [--constant=<constant>] [--global=<global>] [--format=<format>]
@@ -153,7 +153,7 @@ wp config get [--fields=<fields>] [--constant=<constant>] [--global=<global>] [-
 
 ### wp config path
 
-Get the path to wp-config.php file.
+Gets the path to wp-config.php file.
 
 ~~~
 wp config path 

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -2,7 +2,7 @@
 use \WP_CLI\Utils;
 
 /**
- * Manage the wp-config.php file
+ * Creates and retrieves the wp-config.php file.
  */
 class Config_Command extends WP_CLI_Command {
 

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -18,7 +18,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Generate a wp-config.php file.
+	 * Generates a wp-config.php file.
 	 *
 	 * Creates a new wp-config.php with database constants, and verifies that
 	 * the database constants are correct.
@@ -163,7 +163,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the path to wp-config.php file.
+	 * Gets the path to wp-config.php file.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -183,7 +183,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get variables, constants, and file includes defined in wp-config.php file.
+	 * Gets variables, constants, and file includes defined in wp-config.php file.
 	 *
 	 * ## OPTIONS
 	 *
@@ -290,7 +290,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Filter wp-config.php file configurations.
+	 * Filters wp-config.php file configurations.
 	 *
 	 * @param array $list
 	 * @param array $previous_list
@@ -364,7 +364,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Generate a unique key/salt for the wp-config.php file.
+	 * Generates a unique key/salt for the wp-config.php file.
 	 *
 	 * @throws Exception
 	 *


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for config commands and subcommands to use third-person singular verbs.