### PR TITLE
Restructure config value retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,13 @@ file.
 List variables, constants, and file includes defined in wp-config.php file.
 
 ~~~
-wp config list [--fields=<fields>] [--format=<format>]
+wp config list [<filter>...] [--fields=<fields>] [--format=<format>] [--strict]
 ~~~
 
 **OPTIONS**
+
+	[<filter>...]
+		Key or partial key to filter the list by.
 
 	[--fields=<fields>]
 		Limit the output to specific fields. Defaults to all fields.
@@ -161,10 +164,13 @@ wp config list [--fields=<fields>] [--format=<format>]
 		  - yaml
 		---
 
+	[--strict]
+		Enforce strict matching when a filter is provided.
+
 **EXAMPLES**
 
     # List variables and constants defined in wp-config.php file.
-    $ wp config list --format=table
+    $ wp config list
     +------------------+------------------------------------------------------------------+----------+
     | key              | value                                                            | type     |
     +------------------+------------------------------------------------------------------+----------+
@@ -174,6 +180,26 @@ wp config list [--fields=<fields>] [--format=<format>]
     | DB_PASSWORD      | root                                                             | constant |
     | AUTH_KEY         | r6+@shP1yO&$)1gdu.hl[/j;7Zrvmt~o;#WxSsa0mlQOi24j2cR,7i+QM/#7S:o^ | constant |
     | SECURE_AUTH_KEY  | iO-z!_m--YH$Tx2tf/&V,YW*13Z_HiRLqi)d?$o-tMdY+82pK$`T.NYW~iTLW;xp | constant |
+    +------------------+------------------------------------------------------------------+----------+
+
+    # List only database user and password from wp-config.php file.
+    $ wp config list DB_USER DB_PASSWORD --strict
+    +------------------+-------+----------+
+    | key              | value | type     |
+    +------------------+-------+----------+
+    | DB_USER          | root  | constant |
+    | DB_PASSWORD      | root  | constant |
+    +------------------+-------+----------+
+
+    # List all salts from wp-config.php file.
+    $ wp config list _SALT
+    +------------------+------------------------------------------------------------------+----------+
+    | key              | value                                                            | type     |
+    +------------------+------------------------------------------------------------------+----------+
+    | AUTH_SALT        | n:]Xditk+_7>Qi=>BmtZHiH-6/Ecrvl(V5ceeGP:{>?;BT^=[B3-0>,~F5z$(+Q$ | constant |
+    | SECURE_AUTH_SALT | ?Z/p|XhDw3w}?c.z%|+BAr|(Iv*H%%U+Du&kKR y?cJOYyRVRBeB[2zF-`(>+LCC | constant |
+    | LOGGED_IN_SALT   | +$@(1{b~Z~s}Cs>8Y]6[m6~TnoCDpE>O%e75u}&6kUH!>q:7uM4lxbB6[1pa_X,q | constant |
+    | NONCE_SALT       | _x+F li|QL?0OSQns1_JZ{|Ix3Jleox-71km/gifnyz8kmo=w-;@AE8W,(fP<N}2 | constant |
     +------------------+------------------------------------------------------------------+----------+
 
 

--- a/README.md
+++ b/README.md
@@ -106,22 +106,49 @@ the database constants are correct.
 
 ### wp config get
 
-Gets variables, constants, and file includes defined in wp-config.php file.
+Get the value of a specific variable or constant defined in wp-config.php
 
 ~~~
-wp config get [--fields=<fields>] [--constant=<constant>] [--global=<global>] [--format=<format>]
+wp config get <key> [--type=<type>]
+~~~
+
+file.
+
+**OPTIONS**
+
+	<key>
+		Key for the wp-config.php variable or constant.
+
+	[--type=<type>]
+		Type of config value to retrieve. Defaults to 'all'.
+		---
+		default: all
+		options:
+		  - constant
+		  - variable
+		  - all
+		---
+
+**EXAMPLES**
+
+    # Get the table_prefix as defined in wp-config.php file.
+    $ wp config get table_prefix
+    wp_
+
+
+
+### wp config list
+
+List variables, constants, and file includes defined in wp-config.php file.
+
+~~~
+wp config list [--fields=<fields>] [--format=<format>]
 ~~~
 
 **OPTIONS**
 
 	[--fields=<fields>]
 		Limit the output to specific fields. Defaults to all fields.
-
-	[--constant=<constant>]
-		Returns the value of a specific constant defined in the wp-config.php file.
-
-	[--global=<global>]
-		Returns the value of a specific global defined in the wp-config.php file.
 
 	[--format=<format>]
 		Render output in a particular format.
@@ -137,7 +164,7 @@ wp config get [--fields=<fields>] [--constant=<constant>] [--global=<global>] [-
 **EXAMPLES**
 
     # List variables and constants defined in wp-config.php file.
-    $ wp config get --format=table
+    $ wp config list --format=table
     +------------------+------------------------------------------------------------------+----------+
     | key              | value                                                            | type     |
     +------------------+------------------------------------------------------------------+----------+

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the database constants are correct.
 
 ### wp config get
 
-Get the value of a specific variable or constant defined in wp-config.php
+Gets the value of a specific variable or constant defined in wp-config.php
 
 ~~~
 wp config get <key> [--type=<type>]
@@ -139,7 +139,7 @@ file.
 
 ### wp config list
 
-List variables, constants, and file includes defined in wp-config.php file.
+Lists variables, constants, and file includes defined in wp-config.php file.
 
 ~~~
 wp config list [<filter>...] [--fields=<fields>] [--format=<format>] [--strict]

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
             "config",
             "config create",
             "config get",
+            "config list",
             "config path"
         ]
     }

--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -1,58 +1,90 @@
-Feature: Get the value of a constant or global defined in wp-config.php file
+Feature: Get the value of a constant or variable defined in wp-config.php file
 
   Background:
     Given a WP install
 
   Scenario: Get the value of an existing wp-config.php constant
-    When I try `wp config get --constant=DB_NAME`
+    When I try `wp config get DB_NAME --type=constant`
     Then STDOUT should be:
       """
       wp_cli_test
       """
     And STDERR should be empty
 
-  Scenario: Get the value of an existing wp-config.php global
-    When I try `wp config get --global=table_prefix`
+  Scenario: Get the value of an existing wp-config.php constant without explicit type
+    When I try `wp config get DB_NAME`
+    Then STDOUT should be:
+      """
+      wp_cli_test
+      """
+    And STDERR should be empty
+
+  Scenario: Get the value of an existing wp-config.php variable
+    When I try `wp config get table_prefix --type=variable`
     Then STDOUT should be:
       """
       wp_
       """
     And STDERR should be empty
 
+  Scenario: Get the value of an existing wp-config.php variable without explicit type
+    When I try `wp config get table_prefix`
+    Then STDOUT should be:
+      """
+      wp_
+      """
+    And STDERR should be empty
+
+  Scenario: Get the value of a non existing wp-config.php key
+    When I try `wp config get FOO`
+    Then STDERR should be:
+      """
+      Error: The 'FOO' variable or constant is not defined in the wp-config.php file.
+      """
+    And STDOUT should be empty
+
   Scenario: Get the value of a non existing wp-config.php constant
-    When I try `wp config get --constant=FOO`
+    When I try `wp config get FOO --type=constant`
     Then STDERR should be:
       """
       Error: The 'FOO' constant is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
-  Scenario: Get the value of a non existing wp-config.php global
-    When I try `wp config get --global=foo`
+  Scenario: Get the value of a non existing wp-config.php variable
+    When I try `wp config get foo --type=variable`
     Then STDERR should be:
       """
-      Error: The 'foo' global is not defined in the wp-config.php file.
+      Error: The 'foo' variable is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
   Scenario: Get the value of an existing wp-config.php constant with wrong case should yield an error
-    When I try `wp config get --constant=db_name`
+    When I try `wp config get db_name --type=constant`
     Then STDERR should be:
       """
       Error: The 'db_name' constant is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
-  Scenario: Get the value of an existing wp-config.php global with wrong case should yield an error
-    When I try `wp config get --global=TABLE_PREFIX`
+  Scenario: Get the value of an existing wp-config.php variable with wrong case should yield an error
+    When I try `wp config get TABLE_PREFIX --type=variable`
     Then STDERR should be:
       """
-      Error: The 'TABLE_PREFIX' global is not defined in the wp-config.php file.
+      Error: The 'TABLE_PREFIX' variable is not defined in the wp-config.php file.
+      """
+    And STDOUT should be empty
+
+  Scenario: Get the value of an existing wp-config.php key with wrong case should yield an error
+    When I try `wp config get TABLE_PREFIX`
+    Then STDERR should be:
+      """
+      Error: The 'TABLE_PREFIX' variable or constant is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
   Scenario: Get the value of an existing wp-config.php constant with some similarity should yield a helpful error
-    When I try `wp config get --constant=DB_NOME`
+    When I try `wp config get DB_NOME --type=constant`
     Then STDERR should be:
       """
       Error: The 'DB_NOME' constant is not defined in the wp-config.php file.
@@ -61,34 +93,43 @@ Feature: Get the value of a constant or global defined in wp-config.php file
     And STDOUT should be empty
 
   Scenario: Get the value of an existing wp-config.php constant with some similarity should yield a helpful error
-    When I try `wp config get --global=table_perfix`
+    When I try `wp config get table_perfix --type=variable`
     Then STDERR should be:
       """
-      Error: The 'table_perfix' global is not defined in the wp-config.php file.
+      Error: The 'table_perfix' variable is not defined in the wp-config.php file.
       Did you mean 'table_prefix'?
       """
     And STDOUT should be empty
 
+  Scenario: Get the value of an existing wp-config.php key with some similarity should yield a helpful error
+    When I try `wp config get DB_NOME`
+    Then STDERR should be:
+      """
+      Error: The 'DB_NOME' variable or constant is not defined in the wp-config.php file.
+      Did you mean 'DB_NAME'?
+      """
+    And STDOUT should be empty
+
   Scenario: Get the value of an existing wp-config.php constant with remote similarity should yield just an error
-    When I try `wp config get --constant=DB_NOOOOZLE`
+    When I try `wp config get DB_NOOOOZLE --type=constant`
     Then STDERR should be:
       """
       Error: The 'DB_NOOOOZLE' constant is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
-  Scenario: Get the value of an existing wp-config.php global with remote similarity should yield just an error
-    When I try `wp config get --global=tabre_peffix`
+  Scenario: Get the value of an existing wp-config.php variable with remote similarity should yield just an error
+    When I try `wp config get tabre_peffix --type=variable`
     Then STDERR should be:
       """
-      Error: The 'tabre_peffix' global is not defined in the wp-config.php file.
+      Error: The 'tabre_peffix' variable is not defined in the wp-config.php file.
       """
     And STDOUT should be empty
 
-  Scenario: Trying to get the value of a constant and a global should yield an error
-    When I try `wp config get --constant=DB_NAME --global=table_prefix`
+  Scenario: Get the value of an existing wp-config.php key with remote similarity should yield just an error
+    When I try `wp config get DB_NOOOOZLE`
     Then STDERR should be:
       """
-      Error: Cannot request the value of a constant and a global at the same time.
+      Error: The 'DB_NOOOOZLE' variable or constant is not defined in the wp-config.php file.
       """
     And STDOUT should be empty

--- a/features/config-list.feature
+++ b/features/config-list.feature
@@ -1,0 +1,156 @@
+Feature: List the values of a wp-config.php file
+
+  Scenario: List constants, variables and files included from wp-config.php
+    Given an empty directory
+    And WP files
+    And a wp-config-extra.php file:
+      """
+      require_once 'custom-include.php';
+      """
+    And a custom-include.php file:
+      """
+      <?php // This won't work without this file being empty. ?>
+      """
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < wp-config-extra.php`
+    Then STDOUT should contain:
+      """
+      Generated 'wp-config.php' file.
+      """
+
+    When I run `wp config list --fields=key,type`
+    Then STDOUT should be a table containing rows:
+      | key                | type     |
+      | DB_NAME            | constant |
+      | DB_USER            | constant |
+      | DB_PASSWORD        | constant |
+      | DB_HOST            | constant |
+      | custom-include.php | includes |
+
+    When I try `wp config list`
+    Then STDOUT should be a table containing rows:
+      | key | value | type |
+
+  Scenario: Filter the list of values of a wp-config.php file
+    Given an empty directory
+    And WP files
+    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    Then STDOUT should contain:
+      """
+      Generated 'wp-config.php' file.
+      """
+
+    When I run `wp config list --fields=key`
+    Then STDOUT should be a table containing rows:
+      | key              |
+      | table_prefix     |
+      | DB_NAME          |
+      | DB_USER          |
+      | DB_PASSWORD      |
+      | DB_HOST          |
+      | DB_CHARSET       |
+      | DB_COLLATE       |
+      | AUTH_KEY         |
+      | SECURE_AUTH_KEY  |
+      | LOGGED_IN_KEY    |
+      | NONCE_KEY        |
+      | AUTH_SALT        |
+      | SECURE_AUTH_SALT |
+      | LOGGED_IN_SALT   |
+      | NONCE_SALT       |
+
+    When I run `wp config list --fields=key DB_`
+    Then STDOUT should be a table containing rows:
+      | key              |
+      | DB_NAME          |
+      | DB_USER          |
+      | DB_PASSWORD      |
+      | DB_HOST          |
+      | DB_CHARSET       |
+      | DB_COLLATE       |
+    Then STDOUT should not contain:
+      """
+      table_prefix
+      """
+    Then STDOUT should not contain:
+      """
+      AUTH_KEY
+      """
+
+    When I run `wp config list --fields=key DB_HOST`
+    Then STDOUT should be a table containing rows:
+      | key              |
+      | DB_HOST          |
+    Then STDOUT should not contain:
+      """
+      table_prefix
+      """
+    Then STDOUT should not contain:
+      """
+      AUTH_KEY
+      """
+    Then STDOUT should not contain:
+      """
+      DB_NAME
+      """
+
+    When I try `wp config list --fields=key DB_ --strict`
+    Then STDERR should be:
+      """
+      Error: No matching keys found in 'wp-config.php'.
+      """
+
+    When I run `wp config list --fields=key DB_USER DB_PASSWORD`
+    Then STDOUT should be a table containing rows:
+      | key              |
+      | DB_USER          |
+      | DB_PASSWORD      |
+    Then STDOUT should not contain:
+      """
+      table_prefix
+      """
+    Then STDOUT should not contain:
+      """
+      AUTH_KEY
+      """
+    Then STDOUT should not contain:
+      """
+      DB_HOST
+      """
+
+    When I run `wp config list --fields=key DB_USER DB_PASSWORD --strict`
+    Then STDOUT should be a table containing rows:
+      | key              |
+      | DB_USER          |
+      | DB_PASSWORD      |
+    Then STDOUT should not contain:
+      """
+      table_prefix
+      """
+    Then STDOUT should not contain:
+      """
+      AUTH_KEY
+      """
+    Then STDOUT should not contain:
+      """
+      DB_HOST
+      """
+
+    When I run `wp config list --fields=key _KEY _SALT`
+    Then STDOUT should be a table containing rows:
+      | key              |
+      | AUTH_KEY         |
+      | SECURE_AUTH_KEY  |
+      | LOGGED_IN_KEY    |
+      | NONCE_KEY        |
+      | AUTH_SALT        |
+      | SECURE_AUTH_SALT |
+      | LOGGED_IN_SALT   |
+      | NONCE_SALT       |
+    Then STDOUT should not contain:
+      """
+      table_prefix
+      """
+    Then STDOUT should not contain:
+      """
+      DB_HOST
+      """

--- a/features/config-list.feature
+++ b/features/config-list.feature
@@ -93,6 +93,12 @@ Feature: List the values of a wp-config.php file
       DB_NAME
       """
 
+    When I try `wp config list --fields=key --strict`
+    Then STDERR should be:
+      """
+      Error: The --strict option can only be used in combination with a filter.
+      """
+
     When I try `wp config list --fields=key DB_ --strict`
     Then STDERR should be:
       """

--- a/features/config.feature
+++ b/features/config.feature
@@ -9,13 +9,7 @@ Feature: Manage wp-config.php file
       Error: 'wp-config.php' not found.
       """
 
-    When I try `wp config get`
-    Then STDERR should be:
-      """
-      Error: 'wp-config.php' not found.
-      """
-
-    When I try `wp config set`
+    When I try `wp config get SOME_KEY`
     Then STDERR should be:
       """
       Error: 'wp-config.php' not found.

--- a/features/config.feature
+++ b/features/config.feature
@@ -1,6 +1,6 @@
 Feature: Manage wp-config.php file
 
-  Scenario: List constants, globals and files included from wp-config.php
+  Scenario: List constants, variables and files included from wp-config.php
     Given an empty directory
     And WP files
     And a wp-config-extra.php file:
@@ -17,7 +17,7 @@ Feature: Manage wp-config.php file
       Generated 'wp-config.php' file.
       """
 
-    When I run `wp config get --fields=key,type`
+    When I run `wp config list --fields=key,type`
     Then STDOUT should be a table containing rows:
       | key                | type     |
       | DB_NAME            | constant |
@@ -26,14 +26,14 @@ Feature: Manage wp-config.php file
       | DB_HOST            | constant |
       | custom-include.php | includes |
 
-    When I try `wp config get`
+    When I try `wp config list`
     Then STDOUT should be a table containing rows:
       | key | value | type |
 
   Scenario: Getting config should produce error when no config is found
     Given an empty directory
 
-    When I try `wp config get`
+    When I try `wp config list`
     Then STDERR should be:
       """
       Error: 'wp-config.php' not found.

--- a/features/config.feature
+++ b/features/config.feature
@@ -7,18 +7,21 @@ Feature: Manage wp-config.php file
     Then STDERR should be:
       """
       Error: 'wp-config.php' not found.
+      Either create one manually or use `wp config create`.
       """
 
     When I try `wp config get SOME_KEY`
     Then STDERR should be:
       """
       Error: 'wp-config.php' not found.
+      Either create one manually or use `wp config create`.
       """
 
     When I try `wp config path`
     Then STDERR should be:
       """
       Error: 'wp-config.php' not found.
+      Either create one manually or use `wp config create`.
       """
 
   Scenario: Get a wp-config.php file path

--- a/features/config.feature
+++ b/features/config.feature
@@ -1,39 +1,21 @@
 Feature: Manage wp-config.php file
 
-  Scenario: List constants, variables and files included from wp-config.php
-    Given an empty directory
-    And WP files
-    And a wp-config-extra.php file:
-      """
-      require_once 'custom-include.php';
-      """
-    And a custom-include.php file:
-      """
-      <?php // This won't work without this file being empty. ?>
-      """
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < wp-config-extra.php`
-    Then STDOUT should contain:
-      """
-      Generated 'wp-config.php' file.
-      """
-
-    When I run `wp config list --fields=key,type`
-    Then STDOUT should be a table containing rows:
-      | key                | type     |
-      | DB_NAME            | constant |
-      | DB_USER            | constant |
-      | DB_PASSWORD        | constant |
-      | DB_HOST            | constant |
-      | custom-include.php | includes |
-
-    When I try `wp config list`
-    Then STDOUT should be a table containing rows:
-      | key | value | type |
-
   Scenario: Getting config should produce error when no config is found
     Given an empty directory
 
     When I try `wp config list`
+    Then STDERR should be:
+      """
+      Error: 'wp-config.php' not found.
+      """
+
+    When I try `wp config get`
+    Then STDERR should be:
+      """
+      Error: 'wp-config.php' not found.
+      """
+
+    When I try `wp config set`
     Then STDERR should be:
       """
       Error: 'wp-config.php' not found.

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -183,7 +183,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * List variables, constants, and file includes defined in wp-config.php file.
+	 * Lists variables, constants, and file includes defined in wp-config.php file.
 	 *
 	 * ## OPTIONS
 	 *
@@ -283,7 +283,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the value of a specific variable or constant defined in wp-config.php
+	 * Gets the value of a specific variable or constant defined in wp-config.php
 	 * file.
 	 *
 	 * ## OPTIONS
@@ -456,7 +456,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Filter the values based on a provider filter key.
+	 * Filters the values based on a provider filter key.
 	 *
 	 * @param array $values
 	 * @param array $filters

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -246,7 +246,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list_( $args, $assoc_args ) {
- 	    $path = Utils\locate_wp_config();
+		$path = Utils\locate_wp_config();
 		if ( ! $path ) {
 			WP_CLI::error( "'wp-config.php' not found." );
 		}
@@ -310,7 +310,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function get( $args, $assoc_args ) {
- 	    $path = Utils\locate_wp_config();
+		$path = Utils\locate_wp_config();
 		if ( ! $path ) {
 			WP_CLI::error( "'wp-config.php' not found." );
 		}
@@ -328,14 +328,14 @@ class Config_Command extends WP_CLI_Command {
 	 * @return array
 	 */
 	private static function get_wp_config_vars() {
- 	    $wp_cli_original_defined_constants = get_defined_constants();
+		$wp_cli_original_defined_constants = get_defined_constants();
 		$wp_cli_original_defined_vars      = get_defined_vars();
 		$wp_cli_original_includes          = get_included_files();
 
 		eval( WP_CLI::get_runner()->get_wp_config_code() );
 
 		$wp_config_vars      = self::get_wp_config_diff( get_defined_vars(), $wp_cli_original_defined_vars, 'variable', array( 'wp_cli_original_defined_vars' ) );
- 		$wp_config_constants = self::get_wp_config_diff( get_defined_constants(), $wp_cli_original_defined_constants, 'constant' );
+		$wp_config_constants = self::get_wp_config_diff( get_defined_constants(), $wp_cli_original_defined_constants, 'constant' );
 
 		foreach ( $wp_config_vars as $key => $value ) {
 			if ( 'wp_cli_original_includes' === $value['key'] ) {
@@ -357,7 +357,7 @@ class Config_Command extends WP_CLI_Command {
 			);
 		}
 
- 		return array_merge( $wp_config_vars, $wp_config_constants, $wp_config_includes_array );
+		return array_merge( $wp_config_vars, $wp_config_constants, $wp_config_includes_array );
 	}
 
 	/**

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -317,9 +317,6 @@ class Config_Command extends WP_CLI_Command {
 			);
 		}
 
-		$get_constant = ! empty( $assoc_args['constant'] );
-		$get_variable   = ! empty( $assoc_args['variable'] );
-
  		return array_merge( $wp_config_vars, $wp_config_constants, $wp_config_includes_array );
 	}
 

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -174,12 +174,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function path() {
-		$path = Utils\locate_wp_config();
-		if ( $path ) {
-			WP_CLI::line( $path );
-		} else {
-			WP_CLI::error( "'wp-config.php' not found." );
-		}
+		WP_CLI::line( $this->get_config_path() );
 	}
 
 	/**
@@ -246,10 +241,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list_( $args, $assoc_args ) {
-		$path = Utils\locate_wp_config();
-		if ( ! $path ) {
-			WP_CLI::error( "'wp-config.php' not found." );
-		}
+		$path = $this->get_config_path();
 
 		$strict = Utils\get_flag_value( $assoc_args, 'strict' );
 		if ( $strict && empty( $args ) ) {
@@ -310,10 +302,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function get( $args, $assoc_args ) {
-		$path = Utils\locate_wp_config();
-		if ( ! $path ) {
-			WP_CLI::error( "'wp-config.php' not found." );
-		}
+		$path = $this->get_config_path();
 
 		list( $key ) = $args;
 		$type = Utils\get_flag_value( $assoc_args, 'type' );
@@ -482,6 +471,20 @@ class Config_Command extends WP_CLI_Command {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Gets the path to the wp-config.php file or gives a helpful error if none
+	 * found.
+	 *
+	 * @return string Path to wp-config.php file.
+	 */
+	private function get_config_path() {
+		$path = Utils\locate_wp_config();
+		if ( ! $path ) {
+			WP_CLI::error( "'wp-config.php' not found.\nEither create one manually or use `wp config create`." );
+		}
+		return $path;
 	}
 }
 

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -217,8 +217,9 @@ class Config_Command extends WP_CLI_Command {
 	 *     +------------------+------------------------------------------------------------------+----------+
 	 *
 	 * @when before_wp_load
+	 * @subcommand list
 	 */
-	public function list( $_, $assoc_args ) {
+	public function list_( $_, $assoc_args ) {
  	    $path = Utils\locate_wp_config();
 		if ( ! $path ) {
 			WP_CLI::error( "'wp-config.php' not found." );


### PR DESCRIPTION
`wp config list` now produces a list of all config variables, constants and included files.

`wp config get <key>` now retrieves the value of the requested config key.

Note: Default behavior is to retrieve whatever key happens to fit, across both constants and variables. In case there's an ambiguous key that happens to exist as both a variable and a constant (which should be pretty rare), it will throw an error and ask for an explicit `--type=<type>` to disambiguate.