### PR TITLE
Fix library version to `^1.2.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "files": [ "config-command.php" ]
     },
     "require": {
-        "wp-cli/wp-config-transformer": "^1.2"
+        "wp-cli/wp-config-transformer": "^1.2.1"
     },
     "require-dev": {
         "behat/behat": "~2.5",


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-config-transformer/issues/2