### PR TITLE
Set WP_CACHE_KEY_SALT

### DIFF
--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -138,6 +138,7 @@ class Config_Command extends WP_CLI_Command {
 				$assoc_args['secure-auth-salt'] = self::unique_key();
 				$assoc_args['logged-in-salt'] = self::unique_key();
 				$assoc_args['nonce-salt'] = self::unique_key();
+				$assoc_args['wp-cache-key-salt'] = self::unique_key();
 			} catch ( Exception $e ) {
 				$assoc_args['keys-and-salts'] = false;
 				$assoc_args['keys-and-salts-alt'] = self::_read(

--- a/templates/wp-config.mustache
+++ b/templates/wp-config.mustache
@@ -47,14 +47,15 @@ define( 'DB_COLLATE', '{{dbcollate}}' );
  * @since 2.6.0
  */
 {{#keys-and-salts}}
-define( 'AUTH_KEY',         '{{auth-key}}' );
-define( 'SECURE_AUTH_KEY',  '{{secure-auth-key}}' );
-define( 'LOGGED_IN_KEY',    '{{logged-in-key}}' );
-define( 'NONCE_KEY',        '{{nonce-key}}' );
-define( 'AUTH_SALT',        '{{auth-salt}}' );
-define( 'SECURE_AUTH_SALT', '{{secure-auth-salt}}' );
-define( 'LOGGED_IN_SALT',   '{{logged-in-salt}}' );
-define( 'NONCE_SALT',       '{{nonce-salt}}' );
+define( 'AUTH_KEY',          '{{auth-key}}' );
+define( 'SECURE_AUTH_KEY',   '{{secure-auth-key}}' );
+define( 'LOGGED_IN_KEY',     '{{logged-in-key}}' );
+define( 'NONCE_KEY',         '{{nonce-key}}' );
+define( 'AUTH_SALT',         '{{auth-salt}}' );
+define( 'SECURE_AUTH_SALT',  '{{secure-auth-salt}}' );
+define( 'LOGGED_IN_SALT',    '{{logged-in-salt}}' );
+define( 'NONCE_SALT',        '{{nonce-salt}}' );
+define( 'WP_CACHE_KEY_SALT', '{{wp-cache-key-salt}}' );
 {{/keys-and-salts}}
 {{keys-and-salts-alt}}
 /**


### PR DESCRIPTION
Sets `WP_CACHE_KEY_SALT` when creating the config file

Fixes #60