### PR TITLE
Feature/50 adding shuffle-salts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,16 +352,6 @@ wp config set <name> <value> [--add] [--raw] [--anchor=<anchor>] [--placement=<p
     # Set the WP_DEBUG constant to true.
     $ wp config set WP_DEBUG true --raw
 
-
-
-### wp config shuffle-salts
-
-Refreshes the salts in the wp-config.php file
-
-~~~
-wp config shuffle-salts
-~~~
-
 ## Installing
 
 This package is included with WP-CLI itself, no additional installation necessary.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,16 @@ wp config set <name> <value> [--add] [--raw] [--anchor=<anchor>] [--placement=<p
     # Set the WP_DEBUG constant to true.
     $ wp config set WP_DEBUG true --raw
 
+
+
+### wp config shuffle-salts
+
+Refreshes the salts in the wp-config.php file
+
+~~~
+wp config shuffle-salts
+~~~
+
 ## Installing
 
 This package is included with WP-CLI itself, no additional installation necessary.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,23 @@ wp config set <name> <value> [--add] [--raw] [--anchor=<anchor>] [--placement=<p
     # Set the WP_DEBUG constant to true.
     $ wp config set WP_DEBUG true --raw
 
+
+
+### wp config shuffle-salts
+
+Refreshes the salts defined in the wp-config.php file
+
+~~~
+wp config shuffle-salts 
+~~~
+
+**OPTIONS**
+
+**EXAMPLES**
+
+    # Get new salts for your wp-config.php file
+    $ wp config shuffle-salts
+
 ## Installing
 
 This package is included with WP-CLI itself, no additional installation necessary.

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ wp config set <name> <value> [--add] [--raw] [--anchor=<anchor>] [--placement=<p
 
 ### wp config shuffle-salts
 
-Refreshes the salts defined in the wp-config.php file
+Refreshes the salts defined in the wp-config.php file.
 
 ~~~
 wp config shuffle-salts 
@@ -368,6 +368,7 @@ wp config shuffle-salts
 
     # Get new salts for your wp-config.php file
     $ wp config shuffle-salts
+    Success: Shuffled the salt keys.
 
 ## Installing
 

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
             "config has",
             "config list",
             "config path",
-            "config set"
+            "config set",
+            "config shuffle-salts"
         ]
     }
 }

--- a/features/config-shuffle-salts.feature
+++ b/features/config-shuffle-salts.feature
@@ -1,0 +1,54 @@
+Feature: Refresh the salts in the wp-config.php file
+
+  Scenario: Salts are created properly when none initially exist
+    Given a WP install
+    When I try `wp config get AUTH_KEY --type=constant`
+    Then STDERR should contain:
+    """
+    The constant 'AUTH_KEY' is not defined in the 'wp-config.php' file.
+    """
+
+    When I run `wp config shuffle-salts`
+    Then STDOUT should contain:
+    """
+    Shuffled the salt keys.
+    """
+    And the wp-config.php file should contain:
+    """
+    define( 'AUTH_KEY'
+    """
+
+  Scenario: Shuffle the salts
+    Given a WP install
+    When I run `wp config shuffle-salts`
+    Then STDOUT should contain:
+    """
+    Shuffled the salt keys.
+    """
+    And the wp-config.php file should contain:
+    """
+    define( 'AUTH_KEY'
+    """
+    And the wp-config.php file should contain:
+    """
+    define( 'LOGGED_IN_SALT'
+    """
+
+    When I run `wp config get AUTH_KEY --type=constant`
+    Then save STDOUT as {AUTH_KEY_ORIG}
+    When I run `wp config get LOGGED_IN_SALT --type=constant`
+    Then save STDOUT as {LOGGED_IN_SALT_ORIG}
+
+    When I run `wp config shuffle-salts`
+    Then STDOUT should contain:
+    """
+    Shuffled the salt keys.
+    """
+    And the wp-config.php file should not contain:
+    """
+    {AUTH_KEY_ORIG}
+    """
+    And the wp-config.php file should not contain:
+    """
+    {LOGGED_IN_SALT_ORIG}
+    """

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -620,7 +620,7 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Refreshes the salts defined in the wp-config.php file
+	 * Refreshes the salts defined in the wp-config.php file.
 	 *
 	 * ## OPTIONS
 	 *
@@ -628,6 +628,7 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 *     # Get new salts for your wp-config.php file
 	 *     $ wp config shuffle-salts
+	 *     Success: Shuffled the salt keys.
 	 *
 	 * @subcommand shuffle-salts
 	 * @when before_wp_load

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -623,55 +623,29 @@ class Config_Command extends WP_CLI_Command {
 	 * Refreshes the salts defined in the wp-config.php file
 	 *
 	 * ## OPTIONS
-	 * [--skip_api]
-	 * : Skips trying to connect to the WordPress API to retrieve the salts.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Get new salts for your wp-config.php file
 	 *     $ wp config shuffle-salts
 	 *
-	 *     # Get new salts without reaching out to the WordPress API
-	 *     $ wp config shuffle-salts --skip_api
-	 *
 	 * @subcommand shuffle-salts
 	 * @when before_wp_load
 	 */
 	public function shuffle_salts( $args, $assoc_args ) {
 
-		/**
-		 * Generate keys and salts using secure CSPRNG; fallback to API if enabled; further fallback to original wp_generate_password().
-		 * Functionality taken from WordPress core. wp-admin/setup-config.php
-		 */
 		try {
-			$chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_ []{}<>~`+=,.;:/?|';
-			$max = strlen($chars) - 1;
 			for ( $i = 0; $i < 8; $i++ ) {
-				$key = '';
-				for ( $j = 0; $j < 64; $j++ ) {
-					$key .= substr( $chars, random_int( 0, $max ), 1 );
-				}
-				$secret_keys[] = $key;
+				$secret_keys[] = self::unique_key();
 			}
 		} catch ( Exception $ex ) {
-			$no_api = Utils\get_flag_value( $assoc_args, 'skip_api' );
 
-			if ( ! $no_api ) {
-				$secret_keys = wp_remote_get( 'https://api.wordpress.org/secret-key/1.1/salt/' );
+			$secret_keys = self::_read( 'https://api.wordpress.org/secret-key/1.1/salt/' );
+			$secret_keys = explode( "\n", $secret_keys );
+			foreach ( $secret_keys as $k => $v ) {
+				$secret_keys[$k] = substr( $v, 28, 64 );
 			}
 
-			if ( $no_api || is_wp_error( $secret_keys ) ) {
-
-				$secret_keys = array();
-				for ( $i = 0; $i < 8; $i++ ) {
-					$secret_keys[] = wp_generate_password( 64, true, true );
-				}
-			} else {
-				$secret_keys = explode( "\n", wp_remote_retrieve_body( $secret_keys ) );
-				foreach ( $secret_keys as $k => $v ) {
-					$secret_keys[$k] = substr( $v, 28, 64 );
-				}
-			}
 		}
 
 		$constant_list = [ 'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY', 'AUTH_SALT', 'SECURE_AUTH_SALT', 'LOGGED_IN_SALT', 'NONCE_SALT' ];

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -620,6 +620,84 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Refreshes the salts defined in the wp-config.php file
+	 *
+	 * ## OPTIONS
+	 * [--skip_api]
+	 * : Skips trying to connect to the WordPress API to retrieve the salts.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get new salts for your wp-config.php file
+	 *     $ wp config shuffle-salts
+	 *
+	 *     # Get new salts without reaching out to the WordPress API
+	 *     $ wp config shuffle-salts --skip_api
+	 *
+	 * @subcommand shuffle-salts
+	 * @when before_wp_load
+	 */
+	public function shuffle_salts( $args, $assoc_args ) {
+
+		/**
+		 * Generate keys and salts using secure CSPRNG; fallback to API if enabled; further fallback to original wp_generate_password().
+		 * Functionality taken from WordPress core. wp-admin/setup-config.php
+		 */
+		try {
+			$chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_ []{}<>~`+=,.;:/?|';
+			$max = strlen($chars) - 1;
+			for ( $i = 0; $i < 8; $i++ ) {
+				$key = '';
+				for ( $j = 0; $j < 64; $j++ ) {
+					$key .= substr( $chars, random_int( 0, $max ), 1 );
+				}
+				$secret_keys[] = $key;
+			}
+		} catch ( Exception $ex ) {
+			$no_api = Utils\get_flag_value( $assoc_args, 'skip_api' );
+
+			if ( ! $no_api ) {
+				$secret_keys = wp_remote_get( 'https://api.wordpress.org/secret-key/1.1/salt/' );
+			}
+
+			if ( $no_api || is_wp_error( $secret_keys ) ) {
+
+				$secret_keys = array();
+				for ( $i = 0; $i < 8; $i++ ) {
+					$secret_keys[] = wp_generate_password( 64, true, true );
+				}
+			} else {
+				$secret_keys = explode( "\n", wp_remote_retrieve_body( $secret_keys ) );
+				foreach ( $secret_keys as $k => $v ) {
+					$secret_keys[$k] = substr( $v, 28, 64 );
+				}
+			}
+		}
+
+		$constant_list = [ 'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY', 'AUTH_SALT', 'SECURE_AUTH_SALT', 'LOGGED_IN_SALT', 'NONCE_SALT' ];
+		$key = 0;
+
+		$path = $this->get_config_path();
+
+		if ( false === $path ) {
+			WP_CLI::error( 'Could not locate wp-config.php file to modify' );
+		}
+
+		try {
+			$config_transformer = new WPConfigTransformer( $path );
+			foreach ( $constant_list as $constant ) {
+				$config_transformer->update( 'constant', $constant, $secret_keys[ $key ] );
+				$key++;
+			}
+		} catch ( Exception $exception ) {
+			WP_CLI::error( "Could not process the 'wp-config.php' transformation.\nReason: " . $exception->getMessage() );
+		}
+
+		WP_CLI::success( 'Shuffled the salt keys.' );
+
+	}
+
+	/**
 	 * Filters wp-config.php file configurations.
 	 *
 	 * @param array $list

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -649,7 +649,6 @@ class Config_Command extends WP_CLI_Command {
 			foreach ( $constant_list as $key ) {
 				$secret_keys[ $key ] = trim( self::unique_key() );
 			}
-			throw new Exception( 'TEST' );
 		} catch ( Exception $ex ) {
 
 			$remote_salts = self::_read( 'https://api.wordpress.org/secret-key/1.1/salt/' );

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -648,7 +648,7 @@ class Config_Command extends WP_CLI_Command {
 
 		}
 
-		$constant_list = [ 'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY', 'AUTH_SALT', 'SECURE_AUTH_SALT', 'LOGGED_IN_SALT', 'NONCE_SALT' ];
+		$constant_list = array( 'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY', 'AUTH_SALT', 'SECURE_AUTH_SALT', 'LOGGED_IN_SALT', 'NONCE_SALT' );
 		$key = 0;
 
 		$path = $this->get_config_path();

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -634,9 +634,20 @@ class Config_Command extends WP_CLI_Command {
 	 */
 	public function shuffle_salts( $args, $assoc_args ) {
 
+		$constant_list = array(
+			'AUTH_KEY',
+			'SECURE_AUTH_KEY',
+			'LOGGED_IN_KEY',
+			'NONCE_KEY',
+			'AUTH_SALT',
+			'SECURE_AUTH_SALT',
+			'LOGGED_IN_SALT',
+			'NONCE_SALT'
+		);
+
 		try {
-			for ( $i = 0; $i < 8; $i++ ) {
-				$secret_keys[] = self::unique_key();
+			foreach ( $constant_list as $key ) {
+				$secret_keys[ $key ] = self::unique_key();
 			}
 		} catch ( Exception $ex ) {
 
@@ -648,16 +659,12 @@ class Config_Command extends WP_CLI_Command {
 
 		}
 
-		$constant_list = array( 'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY', 'AUTH_SALT', 'SECURE_AUTH_SALT', 'LOGGED_IN_SALT', 'NONCE_SALT' );
-		$key = 0;
-
 		$path = $this->get_config_path();
 
 		try {
 			$config_transformer = new WPConfigTransformer( $path );
-			foreach ( $constant_list as $constant ) {
-				$config_transformer->update( 'constant', $constant, $secret_keys[ $key ] );
-				$key++;
+			foreach ( $secret_keys as $constant => $key ) {
+				$config_transformer->update( 'constant', $constant, $key );
 			}
 		} catch ( Exception $exception ) {
 			WP_CLI::error( "Could not process the 'wp-config.php' transformation.\nReason: " . $exception->getMessage() );

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -653,10 +653,6 @@ class Config_Command extends WP_CLI_Command {
 
 		$path = $this->get_config_path();
 
-		if ( false === $path ) {
-			WP_CLI::error( 'Could not locate wp-config.php file to modify' );
-		}
-
 		try {
 			$config_transformer = new WPConfigTransformer( $path );
 			foreach ( $constant_list as $constant ) {


### PR DESCRIPTION
First pass at the shuffle-salts command here. This uses code fairly similar to what core uses here -> https://github.com/WordPress/wordpress-develop/blob/master/src/wp-admin/setup-config.php#L317-L346

I'm also relying on the internal `unique_key` method here which was added in #25 

Working on adding tests now, just wanted to get the first pass up 👍 