### PR TITLE
Ensure `file_put_contents()` writes to the `wp-config.php` path

### DIFF
--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -181,7 +181,7 @@ class Config_Command extends WP_CLI_Command {
 		if ( $r === false ) {
 			WP_CLI::warning( 'No changes made to wp-config.php.', 'Aborted' );
 		} else {
-			file_put_contents( $path, $r );
+			file_put_contents( $config_path, $r );
 		}
 	}
 


### PR DESCRIPTION
Without it, `wp config edit` won't save your changes