### PR TITLE
Change scaffolded config dbhost to '127.0.0.1'

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ the database constants are correct.
 	[--dbhost=<dbhost>]
 		Set the database host.
 		---
-		default: localhost
+		default: 127.0.0.1
 		---
 
 	[--dbprefix=<dbprefix>]

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -37,7 +37,7 @@ class Config_Command extends WP_CLI_Command {
 	 * [--dbhost=<dbhost>]
 	 * : Set the database host.
 	 * ---
-	 * default: localhost
+	 * default: 127.0.0.1
 	 * ---
 	 *
 	 * [--dbprefix=<dbprefix>]
@@ -101,7 +101,7 @@ class Config_Command extends WP_CLI_Command {
 		include $versions_path;
 
 		$defaults = array(
-			'dbhost' => 'localhost',
+			'dbhost' => '127.0.0.1',
 			'dbpass' => '',
 			'dbprefix' => 'wp_',
 			'dbcharset' => 'utf8',


### PR DESCRIPTION
I updated to PHP 7.1 and 'localhost' is no longer available. '127.0.0.1'
seems like a better default.

Previously https://github.com/wp-cli/wp-cli/issues/1593#issuecomment-379511692