### PR TITLE
::log -> ::print_value for output of get cmd

### DIFF
--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -332,7 +332,7 @@ class Config_Command extends WP_CLI_Command {
 		$type = Utils\get_flag_value( $assoc_args, 'type' );
 
 		$value = $this->return_value( $name, $type, self::get_wp_config_vars() );
-		WP_CLI::log( $value );
+		WP_CLI::print_value( $value );
 	}
 
 	/**


### PR DESCRIPTION
Move `get` command from ::log to ::print_value for the output so that --quiet doesn't suppress it.

Fixes #77