### PR TITLE
Add `--format` option for `config get` command

### DIFF
--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -161,3 +161,23 @@ Feature: Get the value of a constant or variable defined in wp-config.php file
       """
       value-b
       """
+
+    Scenario: Format returned values
+      When I run `wp config get DB_NAME`
+      Then STDOUT should be:
+        """
+        wp_cli_test
+        """
+
+      When I run `wp config get DB_NAME --format=json`
+      Then STDOUT should be:
+        """
+        "wp_cli_test"
+        """
+
+      When I run `wp config get DB_NAME --format=yaml`
+      Then STDOUT should be:
+        """
+        ---
+        - wp_cli_test
+        """

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -317,6 +317,16 @@ class Config_Command extends WP_CLI_Command {
 	 *   - all
 	 * ---
 	 *
+	 * [--format=<format>]
+	 * : Get value in a particular format.
+	 * ---
+	 * default: var_export
+	 * options:
+	 *   - var_export
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Get the table_prefix as defined in wp-config.php file.
@@ -332,7 +342,7 @@ class Config_Command extends WP_CLI_Command {
 		$type = Utils\get_flag_value( $assoc_args, 'type' );
 
 		$value = $this->return_value( $name, $type, self::get_wp_config_vars() );
-		WP_CLI::log( $value );
+		WP_CLI::print_value( $value, $assoc_args );
 	}
 
 	/**


### PR DESCRIPTION
As [proposed in Slack](https://wordpress.slack.com/archives/C02RP4T41/p1532097470000028) a painfully long time ago..

This adds a --format option for `wp config get` to return data in var_export, json or yaml format, and the related tests.