### PR TITLE
Escape values to avoid breaking them within single quotes

### DIFF
--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -155,3 +155,20 @@ Feature: Create a wp-config file
       """
       define( 'WPLANG', 'ja' );
       """
+
+  Scenario: Values are properly escaped to avoid creating invalid config files
+    Given an empty directory
+    And WP files
+
+    When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass="PasswordWith'SingleQuotes'"`
+    Then the wp-config.php file should contain:
+      """
+      define( 'DB_PASSWORD', 'PasswordWith\'SingleQuotes\'' )
+      """
+
+    When I run `wp config get DB_PASSWORD`
+    Then STDOUT should be:
+      """
+      PasswordWith'SingleQuotes'
+      """
+

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -191,9 +191,23 @@ class Config_Command extends WP_CLI_Command {
 			$assoc_args['add-wplang'] = false;
 		}
 
-		$assoc_args = array_map( [ $this, 'escape_config_value' ], $assoc_args );
+		// Store 'extra-php' and reinsert later, it mustn't be escaped.
+		if ( array_key_exists( 'extra-php', $assoc_args ) ) {
+			$unescaped_extra_php = $assoc_args['extra-php'];
+			unset( $assoc_args['extra-php'] );
+		}
 
-		// 'extra-php' is retrieved after escaping to avoid breaking the PHP code.
+		$assoc_args = array_map(
+			[ $this, 'escape_config_value' ],
+			$assoc_args
+		);
+
+		if ( isset( $unescaped_extra_php ) ) {
+			$assoc_args['extra-php'] = $unescaped_extra_php;
+		}
+
+		// 'extra-php' from STDIN is retrieved after escaping to avoid breaking
+		// the PHP code.
 		if ( Utils\get_flag_value( $assoc_args, 'extra-php' ) === true ) {
 			$assoc_args['extra-php'] = file_get_contents( 'php://stdin' );
 		}


### PR DESCRIPTION
As the values provided through the user's arguments are printed within single quotes in the `wp-config.php` file's defines, we need to escape them properly to avoid breaking these single quoted strings.

This is a stop-gap measure to fix the bug reported in #93, but the proper solution would be to rewrite according to #94 and centralize all validation and escaping in `wp-cli/wp-config-transformer`.

Fixes #93