### PR TITLE
#98 Add `dotenv` format option to `config get` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,14 @@ wp config get <name> [--type=<type>] [--format=<format>]
 
 	[--format=<format>]
 		Get value in a particular format.
+		Dotenv is limited to non-object values.
 		---
 		default: var_export
 		options:
 		  - var_export
 		  - json
 		  - yaml
+		  - dotenv
 		---
 
 **EXAMPLES**
@@ -241,6 +243,7 @@ wp config list [<filter>...] [--fields=<fields>] [--format=<format>] [--strict]
 
 	[--format=<format>]
 		Render output in a particular format.
+		Dotenv is limited to non-object values.
 		---
 		default: table
 		options:
@@ -248,6 +251,7 @@ wp config list [<filter>...] [--fields=<fields>] [--format=<format>] [--strict]
 		  - csv
 		  - json
 		  - yaml
+		  - dotenv
 		---
 
 	[--strict]

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -221,6 +221,7 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.
+     * Dotenv is limited to non-object values.
 	 * ---
 	 * default: table
 	 * options:
@@ -228,6 +229,7 @@ class Config_Command extends WP_CLI_Command {
 	 *   - csv
 	 *   - json
 	 *   - yaml
+     *   - dotenv
 	 * ---
 	 *
 	 * [--strict]
@@ -325,12 +327,14 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 * [--format=<format>]
 	 * : Get value in a particular format.
+     * Dotenv is limited to non-object values.
 	 * ---
 	 * default: var_export
 	 * options:
 	 *   - var_export
 	 *   - json
 	 *   - yaml
+     *   - dotenv
 	 * ---
 	 *
 	 * ## EXAMPLES


### PR DESCRIPTION
Issue: https://github.com/wp-cli/config-command/issues/98

I don't know how you guys handle this, but the following PR is directly linked (and vice versa).

https://github.com/wp-cli/wp-cli/pull/5284