### PR TITLE
#98 Add `dotenv` format option to `config get` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,14 @@ wp config get <name> [--type=<type>] [--format=<format>]
 
 	[--format=<format>]
 		Get value in a particular format.
+		Dotenv is limited to non-object values.
 		---
 		default: var_export
 		options:
 		  - var_export
 		  - json
 		  - yaml
+		  - dotenv
 		---
 
 **EXAMPLES**
@@ -244,6 +246,7 @@ wp config list [<filter>...] [--fields=<fields>] [--format=<format>] [--strict]
 
 	[--format=<format>]
 		Render output in a particular format.
+		Dotenv is limited to non-object values.
 		---
 		default: table
 		options:
@@ -251,6 +254,7 @@ wp config list [<filter>...] [--fields=<fields>] [--format=<format>] [--strict]
 		  - csv
 		  - json
 		  - yaml
+		  - dotenv
 		---
 
 	[--strict]

--- a/features/config-list.feature
+++ b/features/config-list.feature
@@ -160,3 +160,98 @@ Feature: List the values of a wp-config.php file
       """
       DB_HOST
       """
+
+  Scenario: Configuration can be formatted for dotenv files
+    Given an empty directory
+    And WP files
+    And a wp-config.php file:
+      """
+      <?php
+      define( 'DB_NAME', 'wp_cli_test' );
+      define( 'DB_USER', 'wp_cli_test' );
+      define( 'DB_PASSWORD', 'password1' );
+      define( 'DB_HOST', '127.0.0.1:33068' );
+      define( 'DB_CHARSET', 'utf8' );
+      define( 'DB_COLLATE', '' );
+
+      define('AUTH_KEY',         '7mj0&+HVh{90t.S]m{u)$\'tCCB$:.[7}jAf`)~hS{ZL#v+&F#kA^p|*R<YaMFR,p');
+      define('SECURE_AUTH_KEY',  'c_0aQDj2.s}]rC+,JmU(VG!g4LapYREo+akySvE.M;lS4|Y(u%:f-|5wV_8$Niwm');
+      define('LOGGED_IN_KEY',    '-wRn2hkn >J=FA3Si$i8uco>+6vB0&aej6X4r@2dc]V}|iFE!{CjOA*u#g4@Y.2j');
+      define('NONCE_KEY',        'O..4n~e~(~:7NGyA!q.(`:X,(RcR(n_o|&(*hKrX2+9D=,&1k2k-;>Y_@X+<CwRv');
+      define('AUTH_SALT',        '8+hWU&.Zb ^Fix,Y*|XzaC-*&@?Nw%u(2-G_:6vz0RH(QE5*PP;!h6z{!t>,!6g!');
+      define('SECURE_AUTH_SALT', 'VNH|C>w-z?*dtP4ofy!v%RumM.}ug]mx7$QZW|C-R4T`d-~x|xvL{Xc_5C89K(,^');
+      define('LOGGED_IN_SALT',   'Iwtez|Q`M l7lup; x&ml8^C|Lk&X[3/-l!$`P3GM$7:WI&X$Hn)unjZ9u~g4m[c');
+      define('NONCE_SALT',       'QxcY|80 $f_dRkn*Liu|Ak*aas41g(q5X_h+m8Z$)tf6#TZ+Q,D#%n]g -{=mj1)');
+
+      $table_prefix = 'wp_';
+
+      define( 'WP_ALLOW_MULTISITE', true );
+      define( 'MULTISITE', true );
+      define( 'SUBDOMAIN_INSTALL', false );
+      $base = '/';
+      define( 'DOMAIN_CURRENT_SITE', 'example.com' );
+      define( 'PATH_CURRENT_SITE', '/' );
+      define( 'SITE_ID_CURRENT_SITE', 1 );
+      define( 'BLOG_ID_CURRENT_SITE', 1 );
+
+      /* That's all, stop editing! Happy publishing. */
+
+      if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+      }
+
+      require_once ABSPATH . 'wp-settings.php';
+      """
+
+    When I run `wp config list --fields=name`
+    Then STDOUT should be a table containing rows:
+      | name                 |
+      | table_prefix         |
+      | base                 |
+      | DB_NAME              |
+      | DB_USER              |
+      | DB_PASSWORD          |
+      | DB_HOST              |
+      | DB_CHARSET           |
+      | DB_COLLATE           |
+      | AUTH_KEY             |
+      | SECURE_AUTH_KEY      |
+      | LOGGED_IN_KEY        |
+      | NONCE_KEY            |
+      | AUTH_SALT            |
+      | SECURE_AUTH_SALT     |
+      | LOGGED_IN_SALT       |
+      | NONCE_SALT           |
+      | WP_ALLOW_MULTISITE   |
+      | MULTISITE            |
+      | SUBDOMAIN_INSTALL    |
+      | DOMAIN_CURRENT_SITE  |
+      | PATH_CURRENT_SITE    |
+      | SITE_ID_CURRENT_SITE |
+      | BLOG_ID_CURRENT_SITE |
+
+    When I run `wp config list --format=dotenv`
+    Then STDOUT should be:
+      """
+      DB_NAME='wp_cli_test'
+      DB_USER='wp_cli_test'
+      DB_PASSWORD='password1'
+      DB_HOST='127.0.0.1:33068'
+      DB_CHARSET='utf8'
+      DB_COLLATE=''
+      AUTH_KEY='7mj0&+HVh{90t.S]m{u)$\'tCCB$:.[7}jAf`)~hS{ZL#v+&F#kA^p|*R<YaMFR,p'
+      SECURE_AUTH_KEY='c_0aQDj2.s}]rC+,JmU(VG!g4LapYREo+akySvE.M;lS4|Y(u%:f-|5wV_8$Niwm'
+      LOGGED_IN_KEY='-wRn2hkn >J=FA3Si$i8uco>+6vB0&aej6X4r@2dc]V}|iFE!{CjOA*u#g4@Y.2j'
+      NONCE_KEY='O..4n~e~(~:7NGyA!q.(`:X,(RcR(n_o|&(*hKrX2+9D=,&1k2k-;>Y_@X+<CwRv'
+      AUTH_SALT='8+hWU&.Zb ^Fix,Y*|XzaC-*&@?Nw%u(2-G_:6vz0RH(QE5*PP;!h6z{!t>,!6g!'
+      SECURE_AUTH_SALT='VNH|C>w-z?*dtP4ofy!v%RumM.}ug]mx7$QZW|C-R4T`d-~x|xvL{Xc_5C89K(,^'
+      LOGGED_IN_SALT='Iwtez|Q`M l7lup; x&ml8^C|Lk&X[3/-l!$`P3GM$7:WI&X$Hn)unjZ9u~g4m[c'
+      NONCE_SALT='QxcY|80 $f_dRkn*Liu|Ak*aas41g(q5X_h+m8Z$)tf6#TZ+Q,D#%n]g -{=mj1)'
+      WP_ALLOW_MULTISITE=1
+      MULTISITE=1
+      SUBDOMAIN_INSTALL=''
+      DOMAIN_CURRENT_SITE='example.com'
+      PATH_CURRENT_SITE='/'
+      SITE_ID_CURRENT_SITE=1
+      BLOG_ID_CURRENT_SITE=1
+      """

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -936,8 +936,15 @@ class Config_Command extends WP_CLI_Command {
 			return;
 		}
 
+		$name           = strtoupper( $value['name'] );
 		$variable_value = isset( $value['value'] ) ? $value['value'] : '';
 
-		echo strtoupper( $value['name'] ) . '\"' . addslashes( $variable_value ) . '\"' . PHP_EOL;
+		$variable_value = str_replace( "'", "\'", $variable_value );
+
+		if ( ! is_numeric( $variable_value ) ) {
+			$variable_value = "'{$variable_value}'";
+		}
+
+		WP_CLI::line( "{$name}={$variable_value}" );
 	}
 }

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -250,6 +250,7 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.
+	 * Dotenv is limited to non-object values.
 	 * ---
 	 * default: table
 	 * options:
@@ -257,6 +258,7 @@ class Config_Command extends WP_CLI_Command {
 	 *   - csv
 	 *   - json
 	 *   - yaml
+	 *   - dotenv
 	 * ---
 	 *
 	 * [--strict]
@@ -331,6 +333,10 @@ class Config_Command extends WP_CLI_Command {
 			WP_CLI::error( "No matching entries found in 'wp-config.php'." );
 		}
 
+		if ( 'dotenv' === $assoc_args['format'] ) {
+			return array_walk( $values, array( $this, 'print_dotenv' ) );
+		}
+
 		Utils\format_items( $assoc_args['format'], $values, $assoc_args['fields'] );
 	}
 
@@ -354,12 +360,14 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 * [--format=<format>]
 	 * : Get value in a particular format.
+	 * Dotenv is limited to non-object values.
 	 * ---
 	 * default: var_export
 	 * options:
 	 *   - var_export
 	 *   - json
 	 *   - yaml
+	 *   - dotenv
 	 * ---
 	 *
 	 * ## EXAMPLES
@@ -916,5 +924,20 @@ class Config_Command extends WP_CLI_Command {
 		);
 
 		return $separator;
+	}
+
+	/**
+	 * Writes a provided variable's key and value to stdout, in dotenv format.
+	 *
+	 * @param array $value
+	 */
+	private function print_dotenv( array $value ) {
+		if ( ! isset( $value['name'] ) || ! isset( $value['type'] ) || 'constant' !== $value['type'] ) {
+			return;
+		}
+
+		$variable_value = isset( $value['value'] ) ? $value['value'] : '';
+
+		echo strtoupper( $value['name'] ) . '\"' . addslashes( $variable_value ) . '\"' . PHP_EOL;
 	}
 }


### PR DESCRIPTION
Issue: #98 

Example:

```
╰─ wp config list --format=dotenv
WP_OLD_HASH_PREFIX="$P$"
WP_ENV="development"
WP_HOME="http://example.dev"
WP_SITEURL="http://example.dev/wp"
CONTENT_DIR="/app"
(...)
WP_DEBUG_DISPLAY="1"
SCRIPT_DEBUG="1"
SAVEQUERIES="1"
WP_DEBUG="1"
```