### PR TITLE
Add `--insecure` flag to `config create` & `config shuffle-salts` commands

### DIFF
--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -794,8 +794,8 @@ class Config_Command extends WP_CLI_Command {
 	 * @throws ExitException If the remote request failed.
 	 */
 	private static function read_( $url, $insecure ) {
-		$headers  = [ 'Accept' => 'application/json' ];
-		$options  = [
+		$headers = [ 'Accept' => 'application/json' ];
+		$options = [
 			'timeout'  => 30,
 			'insecure' => $insecure,
 		];

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -799,12 +799,14 @@ class Config_Command extends WP_CLI_Command {
 			'timeout'  => 30,
 			'insecure' => $insecure,
 		];
+
 		$response = Utils\http_request( 'GET', $url, null, $headers, $options );
-		if ( 200 === $response->status_code ) {
-			return $response->body;
-		} else {
+
+		if ( 200 !== $response->status_code ) {
 			WP_CLI::error( "Couldn't fetch response from {$url} (HTTP code {$response->status_code})." );
 		}
+
+		return $response->body;
 	}
 
 	/**

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 use WP_CLI\ExitException;
-use \WP_CLI\Utils;
+use WP_CLI\Utils;
 
 /**
  * Generates and reads the wp-config.php file.
@@ -133,7 +133,7 @@ class Config_Command extends WP_CLI_Command {
 	 *     Success: Generated 'wp-config.php' file.
 	 */
 	public function create( $_, $assoc_args ) {
-		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && Utils\locate_wp_config() ) {
+		if ( ! Utils\get_flag_value( $assoc_args, 'force' ) && Utils\locate_wp_config() ) {
 			WP_CLI::error( "The 'wp-config.php' file already exists." );
 		}
 
@@ -223,7 +223,7 @@ class Config_Command extends WP_CLI_Command {
 		$contents    = file_get_contents( $config_path );
 		$r           = Utils\launch_editor_for_input( $contents, 'wp-config.php', 'php' );
 		if ( false === $r ) {
-			WP_CLI::warning( 'No changes made to wp-config.php.', 'Aborted' );
+			WP_CLI::warning( 'No changes made to wp-config.php, aborted.' );
 		} else {
 			file_put_contents( $config_path, $r );
 		}
@@ -795,7 +795,11 @@ class Config_Command extends WP_CLI_Command {
 	 */
 	private static function read_( $url, $insecure ) {
 		$headers  = [ 'Accept' => 'application/json' ];
-		$response = Utils\http_request( 'GET', $url, null, $headers, [ 'timeout' => 30, 'insecure' => $insecure ] );
+		$options  = [
+			'timeout'  => 30,
+			'insecure' => $insecure,
+		];
+		$response = Utils\http_request( 'GET', $url, null, $headers, $options );
 		if ( 200 === $response->status_code ) {
 			return $response->body;
 		} else {


### PR DESCRIPTION
The PR https://github.com/wp-cli/wp-cli/pull/5523 changes the default behavior for `Utils\http_request()` so that it does not automatically retry a remote request that failed its TLS handshake by skipping certificate validation.

This PR adds the `--insecure` flag to the following commands to explicitly switch back to the previous behavior:

- `config create`
- `config shuffle-salts`