### PR TITLE
Document special `EOF` anchor

### DIFF
--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -439,9 +439,8 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 * [--anchor=<anchor>]
 	 * : Anchor string where additions of new values are anchored around.
-	 * default: "/* That's all, stop editing!".
-	 * option:
-	 *   - EOF
+	 * Defaults to "/* That's all, stop editing!".
+	 * The special case "EOF" string uses the end of the file as the anchor.
 	 *
 	 * [--placement=<placement>]
 	 * : Where to place the new values in relation to the anchor string.

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -439,7 +439,9 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 * [--anchor=<anchor>]
 	 * : Anchor string where additions of new values are anchored around.
-	 * Defaults to "/* That's all, stop editing!".
+	 * default: "/* That's all, stop editing!".
+	 * option:
+	 *   - EOF
 	 *
 	 * [--placement=<placement>]
 	 * : Where to place the new values in relation to the anchor string.


### PR DESCRIPTION
Update documentation to add special-case EOF as possible value.

Replaces #109 
Fixes #97 