### PR TITLE
Update the `wp-config.php` template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,10 @@
     },
     "config": {
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-main": "2.x-dev"
         },
         "bundled": true,
         "commands": [

--- a/features/config-set.feature
+++ b/features/config-set.feature
@@ -223,28 +223,28 @@ Feature: Set the value of a constant or variable defined in wp-config.php file a
   Scenario: Update raw values in wp-config.php
     Given a WP install
 
-    When I run `wp config set WP_DEBUG true --type=constant`
+    When I run `wp config set WP_TEST true --type=constant`
     Then STDOUT should be:
       """
-      Success: Added the constant 'WP_DEBUG' to the 'wp-config.php' file with the value 'true'.
+      Success: Added the constant 'WP_TEST' to the 'wp-config.php' file with the value 'true'.
       """
 
-    When I run `wp config list WP_DEBUG --strict --format=json`
+    When I run `wp config list WP_TEST --strict --format=json`
     Then STDOUT should contain:
       """
-      {"name":"WP_DEBUG","value":"true","type":"constant"}
+      {"name":"WP_TEST","value":"true","type":"constant"}
       """
 
-    When I run `wp config set WP_DEBUG true --raw`
+    When I run `wp config set WP_TEST true --raw`
     Then STDOUT should be:
       """
-      Success: Updated the constant 'WP_DEBUG' in the 'wp-config.php' file with the raw value 'true'.
+      Success: Updated the constant 'WP_TEST' in the 'wp-config.php' file with the raw value 'true'.
       """
 
-    When I run `wp config list WP_DEBUG --strict --format=json`
+    When I run `wp config list WP_TEST --strict --format=json`
     Then STDOUT should contain:
       """
-      {"name":"WP_DEBUG","value":true,"type":"constant"}
+      {"name":"WP_TEST","value":true,"type":"constant"}
       """
 
   @custom-config-file
@@ -258,28 +258,28 @@ Feature: Set the value of a constant or variable defined in wp-config.php file a
       Generated 'wp-custom-config.php' file.
       """
 
-    When I run `wp config set WP_DEBUG true --type=constant --config-file='wp-custom-config.php'`
+    When I run `wp config set WP_TEST true --type=constant --config-file='wp-custom-config.php'`
     Then STDOUT should be:
       """
-      Success: Added the constant 'WP_DEBUG' to the 'wp-custom-config.php' file with the value 'true'.
+      Success: Added the constant 'WP_TEST' to the 'wp-custom-config.php' file with the value 'true'.
       """
 
-    When I run `wp config list WP_DEBUG --strict --format=json --config-file='wp-custom-config.php'`
+    When I run `wp config list WP_TEST --strict --format=json --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
-      {"name":"WP_DEBUG","value":"true","type":"constant"}
+      {"name":"WP_TEST","value":"true","type":"constant"}
       """
 
-    When I run `wp config set WP_DEBUG true --raw --config-file='wp-custom-config.php'`
+    When I run `wp config set WP_TEST true --raw --config-file='wp-custom-config.php'`
     Then STDOUT should be:
       """
-      Success: Updated the constant 'WP_DEBUG' in the 'wp-custom-config.php' file with the raw value 'true'.
+      Success: Updated the constant 'WP_TEST' in the 'wp-custom-config.php' file with the raw value 'true'.
       """
 
-    When I run `wp config list WP_DEBUG --strict --format=json --config-file='wp-custom-config.php'`
+    When I run `wp config list WP_TEST --strict --format=json --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
-      {"name":"WP_DEBUG","value":true,"type":"constant"}
+      {"name":"WP_TEST","value":true,"type":"constant"}
       """
 
   Scenario: Ambiguous change requests for wp-config.php throw errors

--- a/templates/wp-config.mustache
+++ b/templates/wp-config.mustache
@@ -2,15 +2,16 @@
 /**
  * The base configuration for WordPress
  *
- * The wp-config.php creation script uses this file during the
- * installation. You don't have to use the web site, you can
- * copy this file to "wp-config.php" and fill in the values.
+ * The wp-config.php creation script uses this file during the installation.
+ * You don't have to use the web site, you can copy this file to "wp-config.php"
+ * and fill in the values.
  *
  * This file contains the following configurations:
  *
- * * MySQL settings
+ * * Database settings
  * * Secret keys
  * * Database table prefix
+ * * Localized language
  * * ABSPATH
  *
  * @link https://wordpress.org/support/article/editing-wp-config-php/
@@ -18,31 +19,33 @@
  * @package WordPress
  */
 
-// ** MySQL settings - You can get this info from your web host ** //
+// ** Database settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */
 define( 'DB_NAME', '{{dbname}}' );
 
-/** MySQL database username */
+/** Database username */
 define( 'DB_USER', '{{dbuser}}' );
 
-/** MySQL database password */
+/** Database password */
 define( 'DB_PASSWORD', '{{dbpass}}' );
 
-/** MySQL hostname */
+/** Database hostname */
 define( 'DB_HOST', '{{dbhost}}' );
 
-/** Database Charset to use in creating database tables. */
+/** Database charset to use in creating database tables. */
 define( 'DB_CHARSET', '{{dbcharset}}' );
 
-/** The Database Collate type. Don't change this if in doubt. */
+/** The database collate type. Don't change this if in doubt. */
 define( 'DB_COLLATE', '{{dbcollate}}' );
 
-/**
- * Authentication Unique Keys and Salts.
+/**#@+
+ * Authentication unique keys and salts.
  *
- * Change these to different unique phrases!
- * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
- * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ * Change these to different unique phrases! You can generate these using
+ * the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}.
+ *
+ * You can change these at any point in time to invalidate all existing cookies.
+ * This will force all users to have to log in again.
  *
  * @since 2.6.0
  */
@@ -58,17 +61,44 @@ define( 'NONCE_SALT',        '{{nonce-salt}}' );
 define( 'WP_CACHE_KEY_SALT', '{{wp-cache-key-salt}}' );
 {{/keys-and-salts}}
 {{keys-and-salts-alt}}
+
+/**#@-*/
+
 /**
- * WordPress Database Table prefix.
+ * WordPress database table prefix.
  *
  * You can have multiple installations in one database if you give each
  * a unique prefix. Only numbers, letters, and underscores please!
  */
 $table_prefix = '{{dbprefix}}';
 
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the documentation.
+ *
+ * @link https://wordpress.org/support/article/debugging-in-wordpress/
+ */
+define( 'WP_DEBUG', false );
+
 {{#add-wplang}}
+/**
+ * WordPress localized language, defaults to English.
+ *
+ * Change this to localize WordPress. A corresponding MO file for the chosen
+ * language must be installed to wp-content/languages. For example, install
+ * de_DE.mo to wp-content/languages and set WPLANG to 'de_DE' to enable German
+ * language support.
+ */
 define( 'WPLANG', '{{locale}}' );
 {{/add-wplang}}
+
+/* Add any custom values between this line and the "stop editing" line. */
 
 {{extra-php}}
 


### PR DESCRIPTION
This PR updates the `wp-config.php` template to adapt to the latest sample changes. It also adds the `WP_DEBUG` constant, defaulting to `false`.