### PR TITLE
Prevent `WP_DEBUG` already defined when provided via `--extra-php`

### DIFF
--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -66,13 +66,13 @@ Feature: Create a wp-config file
       Error: The site you have requested is not installed
       """
 
+    When I run `rm wp-custom-config.php`
+    Then the wp-custom-config.php file should not exist
+
     Given a wp-config-extra.php file:
       """
       define( 'WP_DEBUG', true );
       """
-
-    When I run `rm wp-custom-config.php`
-    Then the wp-custom-config.php file should not exist
 
     When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
     Then the wp-custom-config.php file should contain:

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -66,6 +66,30 @@ Feature: Create a wp-config file
       Error: The site you have requested is not installed
       """
 
+    Given a wp-config-extra.php file:
+      """
+      define( 'WP_DEBUG', true );
+      """
+
+    When I run `rm wp-custom-config.php`
+    Then the wp-custom-config.php file should not exist
+
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
+    Then the wp-custom-config.php file should contain:
+      """
+      define( 'WP_DEBUG', true );
+      """
+    And the wp-custom-config.php file should contain:
+      """
+      define( 'WP_DEBUG', false );
+      """
+
+    When I try `wp version`
+    Then STDERR should not contain:
+    """
+    Constant WP_DEBUG already defined
+    """
+
   @require-wp-4.0
   Scenario: No wp-config.php and WPLANG
     Given an empty directory

--- a/templates/wp-config.mustache
+++ b/templates/wp-config.mustache
@@ -72,20 +72,6 @@ define( 'WP_CACHE_KEY_SALT', '{{wp-cache-key-salt}}' );
  */
 $table_prefix = '{{dbprefix}}';
 
-/**
- * For developers: WordPress debugging mode.
- *
- * Change this to true to enable the display of notices during development.
- * It is strongly recommended that plugin and theme developers use WP_DEBUG
- * in their development environments.
- *
- * For information on other constants that can be used for debugging,
- * visit the documentation.
- *
- * @link https://wordpress.org/support/article/debugging-in-wordpress/
- */
-define( 'WP_DEBUG', false );
-
 {{#add-wplang}}
 /**
  * WordPress localized language, defaults to English.
@@ -101,6 +87,22 @@ define( 'WPLANG', '{{locale}}' );
 /* Add any custom values between this line and the "stop editing" line. */
 
 {{extra-php}}
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the documentation.
+ *
+ * @link https://wordpress.org/support/article/debugging-in-wordpress/
+ */
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define( 'WP_DEBUG', false );
+}
 
 /* That's all, stop editing! Happy publishing. */
 


### PR DESCRIPTION
This fixes #140 by moving the `WP_DEBUG` define after the output from `{extra_php}` and wrapping it in a conditional. This avoids the `Notice: Constant WP_DEBUG already defined` that gets thrown when `define( 'WP_DEBUG', ... );` is provided via `--extra-php`.
