### PR TITLE
#150 bug example behat

### DIFF
--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -18,6 +18,15 @@ Feature: Get the value of a constant or variable defined in wp-config.php and wp
       wp_cli_test
       """
 
+  Scenario: Get the raw value of an existing wp-config.php constant without explicit type
+  Given a WP install
+
+  When I run `wp config get MYSQL_CLIENT_FLAGS`
+  Then STDOUT should be:
+    """
+    MYSQLI_CLIENT_SSL
+    """
+
   Scenario: Get the value of an existing wp-config.php variable
     Given a WP install
 


### PR DESCRIPTION
See https://github.com/wp-cli/config-command/issues/150

This test doesn't return the expected result. Instead it return `2048`.
The package `php-mysql` should be installed to test this.
Also you need this value in wp-config.php:

`define( 'MYSQL_CLIENT_FLAGS', MYSQLI_CLIENT_SSL );`