### PR TITLE
Add `composer phpcbf` and allow `wordpress-core-installer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "process-timeout": 7200,
         "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "johnpbloch/wordpress-core-installer": true
         }
     },
     "extra": {
@@ -64,6 +65,7 @@
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
         "phpcs": "run-phpcs-tests",
+        "phpcbf": "run-phpcbf-cleanup",
         "phpunit": "run-php-unit-tests",
         "prepare-tests": "install-package-tests",
         "test": [


### PR DESCRIPTION
See https://github.com/wp-cli/.github/issues/41