### PR TITLE
Is-True Command

### DIFF
--- a/features/config-is-true.feature
+++ b/features/config-is-true.feature
@@ -1,113 +1,53 @@
 Feature: Determine whether the value of a constant or variable defined in wp-config.php and wp-custom-config.php files is true.
+  Background:
+    Given an empty directory
+    And WP files
+    And wp-config.php
 
-  Scenario: Get the value of a variable whose value is true
-    Given a WP install
-
-    When I run `wp config set WP_TRUTH true`
+  Scenario Outline: Get the value of a variable whose value is true
+    When I run `wp config set <variable> <value> --type=<type> <raw>`
     Then STDOUT should contain:
     """
     Success:
     """
-    When I try `wp config is-true WP_TRUTH`
+    When I try `wp config is-true <variable>`
     Then STDOUT should be empty
     Then STDERR should be empty
     And the return code should be 0
 
-    When I run `wp config set WP_TRUTH "true"`
+    Examples:
+      | variable          | value     | type      | raw   |
+      | WP_TRUTH          | true      | all       | --raw |
+      | WP_STR_TRUTH      | 'true'    | all       |       |
+      | WP_STRING_MISC    | 'foobar'  | all       |       |
+      | WP_FALSE_STRING   | 'false'   | all       |       |
+      | wp_str_var_truth  | 'true'    | variable  |       |
+      | wp_str_var_false  | 'false'   | variable  |       |
+      | wp_str_var_misc   | 'foobar'  | variable  |       |
+
+  Scenario Outline: Get the value of a variable whose value is not true
+    When I run `wp config set <variable> <value> --type=<type> <raw>`
     Then STDOUT should contain:
     """
     Success:
     """
-    When I try `wp config is-true WP_TRUTH`
-    Then STDOUT should be empty
-    Then STDERR should be empty
-    And the return code should be 0
-
-    When I run `wp config set WP_FALSE_STRING "false"`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true WP_FALSE_STRING`
-    Then STDOUT should be empty
-    Then STDERR should be empty
-    And the return code should be 0
-
-    When I run `wp config set WP_STRING "foobar"`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true WP_STRING`
-    Then STDOUT should be empty
-    Then STDERR should be empty
-    And the return code should be 0
-
-    When I run `wp config set wp_variable_str_true "true" --type=variable`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true wp_variable_str_true`
-    Then STDOUT should be empty
-    Then STDERR should be empty
-    And the return code should be 0
-
-    When I run `wp config set wp_variable_bool_true true --type=variable`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true wp_variable_bool_true`
-    Then STDOUT should be empty
-    Then STDERR should be empty
-    And the return code should be 0
-
-    When I run `wp config set wp_variable_str_false "false" --type=variable`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true wp_variable_str_false`
-    Then STDOUT should be empty
-    Then STDERR should be empty
-    And the return code should be 0
-
-  Scenario: Get the value of a variable whose value is not true
-    Given a WP install
-
-    When I run `wp config set WP_FALSE false --raw`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true WP_FALSE`
+    When I try `wp config is-true <variable>`
     Then STDOUT should be empty
     And the return code should be 1
 
-    When I run `wp config set WP_STRZERO "0"`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true WP_STRZERO`
+    Examples:
+      | variable               | value | type     | raw   |
+      | WP_FALSE               | false | all      | --raw |
+      | WP_STRZERO             | '0'   | all      |       |
+      | WP_NUMZERO             | 0     | all      |       |
+      | wp_variable_bool_false | false | variable | --raw |
+
+  Scenario Outline: Test for values which do not exist
+    When I try `wp config is-true <variable> --type=<type>`
     Then STDOUT should be empty
     And the return code should be 1
 
-    When I run `wp config set WP_NUMZERO 0 --raw`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true WP_NUMZERO`
-    Then STDOUT should be empty
-    And the return code should be 1
-
-    When I run `wp config set wp_variable_bool_false false --raw --type=variable`
-    Then STDOUT should contain:
-    """
-    Success:
-    """
-    When I try `wp config is-true wp_variable_bool_false`
-    Then STDOUT should be empty
-    And the return code should be 1
+    Examples:
+      | variable             | type     |
+      | WP_TEST_CONSTANT_DNE | all      |
+      | wp_test_variable_dne | variable |

--- a/features/config-is-true.feature
+++ b/features/config-is-true.feature
@@ -1,4 +1,4 @@
-Feature: Get the value of a constant or variable defined in wp-config.php and wp-custom-config.php files
+Feature: Determine whether the value of a constant or variable defined in wp-config.php and wp-custom-config.php files is true.
 
   Scenario: Get the value of a variable whose value is true
     Given a WP install

--- a/features/config-is-true.feature
+++ b/features/config-is-true.feature
@@ -4,14 +4,14 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     Given a WP install
 
     When I run `wp config set WP_TRUTH true`
-    When I run `wp config get_truth WP_TRUTH`
+    When I run `wp config is_true WP_TRUTH`
     Then STDOUT should be:
       """
       true
       """
 
     When I run `wp config set WP_TRUTH "true"`
-    When I run `wp config get_truth WP_TRUTH`
+    When I run `wp config is_true WP_TRUTH`
     Then STDOUT should be:
       """
       true
@@ -21,21 +21,21 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     Given a WP install
 
     When I run `wp config set WP_FALSE false`
-    When I run `wp config get_truth WP_FALSE`
+    When I run `wp config is_true WP_FALSE`
     Then STDOUT should be:
       """
       false
       """
 
     When I run `wp config set WP_FALSE_STRING "false"`
-    When I run `wp config get_truth WP_FALSE_STRING`
+    When I run `wp config is_true WP_FALSE_STRING`
     Then STDOUT should be:
       """
       false
       """
 
     When I run `wp config set WP_STRING "foobar"`
-    When I run `wp config get_truth WP_STRING`
+    When I run `wp config is_true WP_STRING`
     Then STDOUT should be:
       """
       false

--- a/features/config-is-true.feature
+++ b/features/config-is-true.feature
@@ -4,39 +4,53 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     Given a WP install
 
     When I run `wp config set WP_TRUTH true`
-    When I run `wp config is_true WP_TRUTH`
-    Then STDOUT should be:
-      """
-      true
-      """
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true WP_TRUTH`
+    Then STDOUT should be empty
+    Then STDERR should be empty
+    And the return code should be 1
 
     When I run `wp config set WP_TRUTH "true"`
-    When I run `wp config is_true WP_TRUTH`
-    Then STDOUT should be:
-      """
-      true
-      """
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true WP_TRUTH`
+    Then STDOUT should be empty
+    Then STDERR should be empty
+    And the return code should be 1
+
+    When I run `wp config set WP_FALSE_STRING "false"`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true WP_FALSE_STRING`
+    Then STDOUT should be empty
+    Then STDERR should be empty
+    And the return code should be 1
+
+    When I run `wp config set WP_STRING "foobar"`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true WP_STRING`
+    Then STDOUT should be empty
+    Then STDERR should be empty
+    And the return code should be 1
 
   Scenario: Get the value of a variable whose value is not true
     Given a WP install
 
-    When I run `wp config set WP_FALSE false`
-    When I run `wp config is_true WP_FALSE`
-    Then STDOUT should be:
-      """
-      false
-      """
-
-    When I run `wp config set WP_FALSE_STRING "false"`
-    When I run `wp config is_true WP_FALSE_STRING`
-    Then STDOUT should be:
-      """
-      false
-      """
-
-    When I run `wp config set WP_STRING "foobar"`
-    When I run `wp config is_true WP_STRING`
-    Then STDOUT should be:
-      """
-      false
-      """
+    When I run `wp config set WP_FALSE false --raw`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true WP_FALSE`
+    Then STDOUT should be empty
+    And the return code should be 0

--- a/features/config-is-true.feature
+++ b/features/config-is-true.feature
@@ -43,6 +43,36 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     Then STDERR should be empty
     And the return code should be 1
 
+    When I run `wp config set wp_variable_str_true "true" --type=variable`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true wp_variable_str_true`
+    Then STDOUT should be empty
+    Then STDERR should be empty
+    And the return code should be 1
+
+    When I run `wp config set wp_variable_bool_true true --type=variable`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true wp_variable_bool_true`
+    Then STDOUT should be empty
+    Then STDERR should be empty
+    And the return code should be 1
+
+    When I run `wp config set wp_variable_str_false "false" --type=variable`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true wp_variable_str_false`
+    Then STDOUT should be empty
+    Then STDERR should be empty
+    And the return code should be 1
+
   Scenario: Get the value of a variable whose value is not true
     Given a WP install
 
@@ -52,5 +82,32 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     Success:
     """
     When I try `wp config is_true WP_FALSE`
+    Then STDOUT should be empty
+    And the return code should be 0
+
+    When I run `wp config set WP_STRZERO "0"`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true WP_STRZERO`
+    Then STDOUT should be empty
+    And the return code should be 0
+
+    When I run `wp config set WP_NUMZERO 0 --raw`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true WP_NUMZERO`
+    Then STDOUT should be empty
+    And the return code should be 0
+
+    When I run `wp config set wp_variable_bool_false false --raw --type=variable`
+    Then STDOUT should contain:
+    """
+    Success:
+    """
+    When I try `wp config is_true wp_variable_bool_false`
     Then STDOUT should be empty
     And the return code should be 0

--- a/features/config-is-true.feature
+++ b/features/config-is-true.feature
@@ -8,7 +8,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true WP_TRUTH`
+    When I try `wp config is-true WP_TRUTH`
     Then STDOUT should be empty
     Then STDERR should be empty
     And the return code should be 0
@@ -18,7 +18,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true WP_TRUTH`
+    When I try `wp config is-true WP_TRUTH`
     Then STDOUT should be empty
     Then STDERR should be empty
     And the return code should be 0
@@ -28,7 +28,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true WP_FALSE_STRING`
+    When I try `wp config is-true WP_FALSE_STRING`
     Then STDOUT should be empty
     Then STDERR should be empty
     And the return code should be 0
@@ -38,7 +38,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true WP_STRING`
+    When I try `wp config is-true WP_STRING`
     Then STDOUT should be empty
     Then STDERR should be empty
     And the return code should be 0
@@ -48,7 +48,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true wp_variable_str_true`
+    When I try `wp config is-true wp_variable_str_true`
     Then STDOUT should be empty
     Then STDERR should be empty
     And the return code should be 0
@@ -58,7 +58,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true wp_variable_bool_true`
+    When I try `wp config is-true wp_variable_bool_true`
     Then STDOUT should be empty
     Then STDERR should be empty
     And the return code should be 0
@@ -68,7 +68,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true wp_variable_str_false`
+    When I try `wp config is-true wp_variable_str_false`
     Then STDOUT should be empty
     Then STDERR should be empty
     And the return code should be 0
@@ -81,7 +81,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true WP_FALSE`
+    When I try `wp config is-true WP_FALSE`
     Then STDOUT should be empty
     And the return code should be 1
 
@@ -90,7 +90,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true WP_STRZERO`
+    When I try `wp config is-true WP_STRZERO`
     Then STDOUT should be empty
     And the return code should be 1
 
@@ -99,7 +99,7 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true WP_NUMZERO`
+    When I try `wp config is-true WP_NUMZERO`
     Then STDOUT should be empty
     And the return code should be 1
 
@@ -108,6 +108,6 @@ Feature: Determine whether the value of a constant or variable defined in wp-con
     """
     Success:
     """
-    When I try `wp config is_true wp_variable_bool_false`
+    When I try `wp config is-true wp_variable_bool_false`
     Then STDOUT should be empty
     And the return code should be 1

--- a/features/config-is-true.feature
+++ b/features/config-is-true.feature
@@ -1,0 +1,42 @@
+Feature: Get the value of a constant or variable defined in wp-config.php and wp-custom-config.php files
+
+  Scenario: Get the value of a variable whose value is true
+    Given a WP install
+
+    When I run `wp config set WP_TRUTH true`
+    When I run `wp config get_truth WP_TRUTH`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    When I run `wp config set WP_TRUTH "true"`
+    When I run `wp config get_truth WP_TRUTH`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+  Scenario: Get the value of a variable whose value is not true
+    Given a WP install
+
+    When I run `wp config set WP_FALSE false`
+    When I run `wp config get_truth WP_FALSE`
+    Then STDOUT should be:
+      """
+      false
+      """
+
+    When I run `wp config set WP_FALSE_STRING "false"`
+    When I run `wp config get_truth WP_FALSE_STRING`
+    Then STDOUT should be:
+      """
+      false
+      """
+
+    When I run `wp config set WP_STRING "foobar"`
+    When I run `wp config get_truth WP_STRING`
+    Then STDOUT should be:
+      """
+      false
+      """

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -421,7 +421,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function get( $args, $assoc_args ) {
-		$value = $this->get_value($assoc_args, $args);
+		$value = $this->get_value( $assoc_args, $args );
 		WP_CLI::print_value( $value, $assoc_args );
 	}
 
@@ -456,7 +456,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function is_true( $args, $assoc_args ) {
-		$value = $this->get_value($assoc_args, $args);
+		$value = $this->get_value( $assoc_args, $args );
 
 		if ( boolval( $value ) ) {
 			WP_CLI::halt( 0 );
@@ -1046,19 +1046,19 @@ class Config_Command extends WP_CLI_Command {
 	/**
 	 * Gets the value of a specific constant or variable defined in wp-config.php file.
 	 *
-	 * @param array $assoc_args
+	 * @param $assoc_args
 	 * @param $args
 	 *
 	 * @return string
 	 */
-	public function get_value( $assoc_args, $args ) {
-		$path = $this->get_config_path($assoc_args);
-		$wp_config_file_name = basename($path);
-		list($name) = $args;
-		$type = Utils\get_flag_value($assoc_args, 'type');
+	protected function get_value( $assoc_args, $args ) {
+		$path                = $this->get_config_path( $assoc_args );
+		$wp_config_file_name = basename( $path );
+		list( $name )        = $args;
+		$type                = Utils\get_flag_value( $assoc_args, 'type' );
 
-		$value = $this->return_value($name, $type,
-			self::get_wp_config_vars($path), $wp_config_file_name);
+		$value = $this->return_value( $name, $type,
+			self::get_wp_config_vars($path), $wp_config_file_name );
 
 		return $value;
 	}

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -460,7 +460,7 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 * @when before_wp_load
 	 */
-	public function get_truth( $args, $assoc_args ) {
+	public function is_true( $args, $assoc_args ) {
 		$path                = $this->get_config_path( $assoc_args );
 		$wp_config_file_name = basename( $path );
 		list( $name )        = $args;

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -458,7 +458,7 @@ class Config_Command extends WP_CLI_Command {
 	public function is_true( $args, $assoc_args ) {
 		$value = $this->get_value($assoc_args, $args);
 
-		if ( $value ) {
+		if ( boolval( $value ) ) {
 			WP_CLI::halt( 1 );
 		}
 		WP_CLI::halt( 0 );

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -431,6 +431,54 @@ class Config_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Determines whether value of a specific constant or variable defined is true.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <name>
+	 * : Name of the wp-config.php constant or variable.
+	 *
+	 * [--type=<type>]
+	 * : Type of config value to retrieve. Defaults to 'all'.
+	 * ---
+	 * default: all
+	 * options:
+	 *   - constant
+	 *   - variable
+	 *   - all
+	 * ---
+	 *
+	 * [--config-file=<path>]
+	 * : Specify the file path to the config file to be read. Defaults to the root of the
+	 * WordPress installation and the filename "wp-config.php".
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get the table_prefix as defined in wp-config.php file.
+	 *     $ wp config get table_prefix
+	 *     wp_
+	 *
+	 * @when before_wp_load
+	 */
+	public function get_truth( $args, $assoc_args ) {
+		$path                = $this->get_config_path( $assoc_args );
+		$wp_config_file_name = basename( $path );
+		list( $name )        = $args;
+		$type                = Utils\get_flag_value( $assoc_args, 'type' );
+
+		$value = $this->return_value( $name, $type, self::get_wp_config_vars( $path ), $wp_config_file_name );
+
+		if ( $value !== true && $value !== 'true') {
+			$value = 'false';
+		}
+		else {
+			$value = 'true';
+		}
+
+		WP_CLI::print_value( $value, $assoc_args );
+	}
+
+	/**
 	 * Get the array of wp-config.php constants and variables.
 	 *
 	 * @param string $wp_config_path Config file path

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -421,12 +421,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function get( $args, $assoc_args ) {
-		$path                = $this->get_config_path( $assoc_args );
-		$wp_config_file_name = basename( $path );
-		list( $name )        = $args;
-		$type                = Utils\get_flag_value( $assoc_args, 'type' );
-
-		$value = $this->return_value( $name, $type, self::get_wp_config_vars( $path ), $wp_config_file_name );
+		$value = $this->get_value($assoc_args, $args);
 		WP_CLI::print_value( $value, $assoc_args );
 	}
 
@@ -461,21 +456,13 @@ class Config_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function is_true( $args, $assoc_args ) {
-		$path                = $this->get_config_path( $assoc_args );
-		$wp_config_file_name = basename( $path );
-		list( $name )        = $args;
-		$type                = Utils\get_flag_value( $assoc_args, 'type' );
+		$value = $this->get_value($assoc_args, $args);
 
-		$value = $this->return_value( $name, $type, self::get_wp_config_vars( $path ), $wp_config_file_name );
-
-		if ( $value !== true && $value !== 'true') {
-			$value = 'false';
+		if ( $value ) {
+			WP_CLI::halt( 1 );
 		}
-		else {
-			$value = 'true';
-		}
+		WP_CLI::halt( 0 );
 
-		WP_CLI::print_value( $value, $assoc_args );
 	}
 
 	/**
@@ -1054,6 +1041,26 @@ class Config_Command extends WP_CLI_Command {
 		);
 
 		return $separator;
+	}
+
+	/**
+	 * Gets the value of a specific constant or variable defined in wp-config.php file.
+	 *
+	 * @param array $assoc_args
+	 * @param $args
+	 *
+	 * @return string
+	 */
+	public function get_value( $assoc_args, $args ) {
+		$path = $this->get_config_path($assoc_args);
+		$wp_config_file_name = basename($path);
+		list($name) = $args;
+		$type = Utils\get_flag_value($assoc_args, 'type');
+
+		$value = $this->return_value($name, $type,
+			self::get_wp_config_vars($path), $wp_config_file_name);
+
+		return $value;
 	}
 
 	/**

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -1058,7 +1058,7 @@ class Config_Command extends WP_CLI_Command {
 		$type                = Utils\get_flag_value( $assoc_args, 'type' );
 
 		$value = $this->return_value( $name, $type,
-			self::get_wp_config_vars($path), $wp_config_file_name );
+			self::get_wp_config_vars( $path ), $wp_config_file_name );
 
 		return $value;
 	}


### PR DESCRIPTION
Resolves https://github.com/wp-cli/config-command/issues/159 by providing `config is-true` command along with related automated tests. 

It creates a protected method `get_value()` to prevent code duplication between the existing `get()` and new `is_true()` methods. 