### PR TITLE
Fail on empty table prefix

### DIFF
--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -119,6 +119,22 @@ Feature: Create a wp-config file
       define( 'AUTH_SALT',
       """
 
+  Scenario: Configure with invalid table prefix
+    Given an empty directory
+    And WP files
+
+    When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=""`
+    Then the return code should be 1
+    And STDERR should not be empty
+
+    When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=" "`
+    Then the return code should be 1
+    And STDERR should not be empty
+
+    When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix="wp-"`
+    Then the return code should be 1
+    And STDERR should not be empty
+
   @require-php-7.0
   Scenario: Configure with salts generated
     Given an empty directory

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -123,20 +123,23 @@ Feature: Create a wp-config file
     Given an empty directory
     And WP files
 
-    When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=""`
-    And STDERR should be:
+    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=""`
+    Then the return code should be 1
+    And STDERR should contain:
       """
       Error: --dbprefix cannot be empty
       """
 
-    When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=" "`
-    And STDERR should be:
+    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=" "`
+    Then the return code should be 1
+    And STDERR should contain:
       """
       Error: --dbprefix can only contain numbers, letters, and underscores.
       """
 
-    When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix="wp-"`
-    And STDERR should be:
+    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix="wp-"`
+    Then the return code should be 1
+    And STDERR should contain:
       """
       Error: --dbprefix can only contain numbers, letters, and underscores.
       """

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -124,16 +124,22 @@ Feature: Create a wp-config file
     And WP files
 
     When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=""`
-    Then the return code should be 1
-    And STDERR should not be empty
+    And STDERR should be:
+      """
+      Error: --dbprefix cannot be empty
+      """
 
     When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=" "`
-    Then the return code should be 1
-    And STDERR should not be empty
+    And STDERR should be:
+      """
+      Error: --dbprefix can only contain numbers, letters, and underscores.
+      """
 
     When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix="wp-"`
-    Then the return code should be 1
-    And STDERR should not be empty
+    And STDERR should be:
+      """
+      Error: --dbprefix can only contain numbers, letters, and underscores.
+      """
 
   @require-php-7.0
   Scenario: Configure with salts generated

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -149,6 +149,9 @@ class Config_Command extends WP_CLI_Command {
 			'config-file' => rtrim( ABSPATH, '/\\' ) . '/wp-config.php',
 		];
 		$assoc_args = array_merge( $defaults, $assoc_args );
+		if ( empty( $assoc_args['dbprefix'] ) ) {
+			WP_CLI::error( '--dbprefix cannot be empty' );
+		}
 		if ( preg_match( '|[^a-z0-9_]|i', $assoc_args['dbprefix'] ) ) {
 			WP_CLI::error( '--dbprefix can only contain numbers, letters, and underscores.' );
 		}


### PR DESCRIPTION
Currently the WP-CLI does allow setting an empty table prefix, this can have problems with some plugins as consequence.
As WordPress does not allow using no table prefix in the web setup, the same should be the case for the WP-CLI.