### PR TITLE
Fix tests for SQLite

### DIFF
--- a/features/config-backcompat.feature
+++ b/features/config-backcompat.feature
@@ -22,7 +22,7 @@ Feature: Backwards compatibility
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check`
     Then STDOUT should contain:
       """
       Generated 'wp-config.php' file.

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -43,7 +43,7 @@ Feature: Create a wp-config file
       define( 'WP_DEBUG_LOG', true );
       """
 
-    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
     Then the wp-custom-config.php file should contain:
       """
       'AUTH_SALT',
@@ -206,7 +206,7 @@ Feature: Create a wp-config file
       define( 'WPLANG', 'ja' );
       """
 
-    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file=wp-custom-config.php --locale=ja --force`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file=wp-custom-config.php --locale=ja --force`
     Then the return code should be 0
     And STDOUT should contain:
       """

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -24,7 +24,7 @@ Feature: Create a wp-config file
       define( 'WP_DEBUG_LOG', true );
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < wp-config-extra.php`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --extra-php < wp-config-extra.php`
     Then the wp-config.php file should contain:
       """
       'AUTH_SALT',
@@ -43,7 +43,7 @@ Feature: Create a wp-config file
       define( 'WP_DEBUG_LOG', true );
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
     Then the wp-custom-config.php file should contain:
       """
       'AUTH_SALT',
@@ -74,7 +74,7 @@ Feature: Create a wp-config file
       define( 'WP_DEBUG', true );
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
     Then the wp-custom-config.php file should contain:
       """
       define( 'WP_DEBUG', true );
@@ -99,7 +99,7 @@ Feature: Create a wp-config file
       define( 'WP_DEBUG_LOG', true );
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < wp-config-extra.php`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --extra-php < wp-config-extra.php`
     Then the wp-config.php file should not contain:
       """
       define( 'WPLANG', '' );
@@ -109,7 +109,7 @@ Feature: Create a wp-config file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-salts --extra-php < /dev/null`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --skip-salts --extra-php < /dev/null`
     Then the wp-config.php file should not contain:
       """
       define('AUTH_SALT',
@@ -123,25 +123,37 @@ Feature: Create a wp-config file
     Given an empty directory
     And WP files
 
-    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=""`
+    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=somepassword --dbprefix=""`
     Then the return code should be 1
     And STDERR should contain:
       """
       Error: --dbprefix cannot be empty
       """
 
-    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix=" "`
+    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=somepassword --dbprefix=" "`
     Then the return code should be 1
     And STDERR should contain:
       """
       Error: --dbprefix can only contain numbers, letters, and underscores.
       """
 
-    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=sompassword --dbprefix="wp-"`
+    When I try `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass=somepassword --dbprefix="wp-"`
     Then the return code should be 1
     And STDERR should contain:
       """
       Error: --dbprefix can only contain numbers, letters, and underscores.
+      """
+
+  @require-mysql
+  Scenario: Configure with invalid database credentials
+    Given an empty directory
+    And WP files
+
+    When I try `wp config create --dbname=somedb --dbuser=someuser --dbpass=somepassword`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: Database connection error
       """
 
   @require-php-7.0
@@ -149,7 +161,7 @@ Feature: Create a wp-config file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check`
     Then the wp-config.php file should contain:
       """
       define( 'AUTH_SALT',
@@ -160,7 +172,7 @@ Feature: Create a wp-config file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS}`
     Then the wp-config.php file should contain:
       """
       define( 'AUTH_SALT',
@@ -170,20 +182,20 @@ Feature: Create a wp-config file
     Given an empty directory
     And I run `wp core download --version=3.9 --force`
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check`
     Then the wp-config.php file should contain:
       """
       define( 'WPLANG', '' );
       """
 
-    When I try `wp core config {CORE_CONFIG_SETTINGS}`
+    When I try `wp config create {CORE_CONFIG_SETTINGS}`
     Then the return code should be 1
     And STDERR should contain:
       """
       Error: The 'wp-config.php' file already exists.
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --locale=ja --force`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --locale=ja --force`
     Then the return code should be 0
     And STDOUT should contain:
       """
@@ -194,7 +206,7 @@ Feature: Create a wp-config file
       define( 'WPLANG', 'ja' );
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file=wp-custom-config.php --locale=ja --force`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file=wp-custom-config.php --locale=ja --force`
     Then the return code should be 0
     And STDOUT should contain:
       """

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -1,5 +1,9 @@
 Feature: Create a wp-config file
 
+  # Skipped for SQLite because `wp db create` does not yet support SQLite.
+  # See https://github.com/wp-cli/db-command/issues/234
+  # and https://github.com/wp-cli/config-command/issues/167
+  @require-mysql
   Scenario: No wp-config.php
     Given an empty directory
     And WP files

--- a/features/config-delete.feature
+++ b/features/config-delete.feature
@@ -47,7 +47,7 @@ Feature: Delete a constant or variable from the wp-config.php file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -117,7 +117,7 @@ Feature: Delete a constant or variable from the wp-config.php file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -173,7 +173,7 @@ Feature: Delete a constant or variable from the wp-config.php file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.

--- a/features/config-delete.feature
+++ b/features/config-delete.feature
@@ -47,7 +47,7 @@ Feature: Delete a constant or variable from the wp-config.php file
     Given an empty directory
     And WP files
 
-    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.

--- a/features/config-edit.feature
+++ b/features/config-edit.feature
@@ -15,7 +15,7 @@ Feature: Edit a wp-config file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}  --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.

--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -164,7 +164,7 @@ Feature: Get the value of a constant or variable defined in wp-config.php and wp
     Given an empty directory
     And WP files
 
-    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.

--- a/features/config-get-field.feature
+++ b/features/config-get-field.feature
@@ -164,7 +164,7 @@ Feature: Get the value of a constant or variable defined in wp-config.php and wp
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}  --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -269,7 +269,7 @@ Feature: Get the value of a constant or variable defined in wp-config.php and wp
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}  --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.

--- a/features/config-has.feature
+++ b/features/config-has.feature
@@ -20,7 +20,7 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}  --config-file='wp-custom-config.php'`
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -29,11 +29,11 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
     Then STDOUT should be empty
     And the return code should be 0
 
-    When I run `wp config has DB_USER --type=constant  --config-file='wp-custom-config.php'`
+    When I run `wp config has DB_USER --type=constant --config-file='wp-custom-config.php'`
     Then STDOUT should be empty
     And the return code should be 0
 
-    When I run `wp config has table_prefix --type=variable  --config-file='wp-custom-config.php'`
+    When I run `wp config has table_prefix --type=variable --config-file='wp-custom-config.php'`
     Then STDOUT should be empty
     And the return code should be 0
 
@@ -70,7 +70,7 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -133,7 +133,7 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.

--- a/features/config-has.feature
+++ b/features/config-has.feature
@@ -20,7 +20,7 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -70,7 +70,7 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -133,7 +133,7 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.

--- a/features/config-list.feature
+++ b/features/config-list.feature
@@ -12,7 +12,7 @@ Feature: List the values of a wp-config.php file
       <?php // This won't work without this file being empty. ?>
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < wp-config-extra.php`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --extra-php < wp-config-extra.php`
     Then STDOUT should contain:
       """
       Generated 'wp-config.php' file.
@@ -43,7 +43,7 @@ Feature: List the values of a wp-config.php file
       <?php // This won't work without this file being empty. ?>
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php' --extra-php < wp-config-extra.php`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -66,7 +66,7 @@ Feature: List the values of a wp-config.php file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check`
     Then STDOUT should contain:
       """
       Generated 'wp-config.php' file.
@@ -198,13 +198,13 @@ Feature: List the values of a wp-config.php file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
       """
 
-    When I run `wp config list --fields=name  --config-file='wp-custom-config.php'`
+    When I run `wp config list --fields=name --config-file='wp-custom-config.php'`
     Then STDOUT should be a table containing rows:
       | name             |
       | table_prefix     |

--- a/features/config-set.feature
+++ b/features/config-set.feature
@@ -20,7 +20,7 @@ Feature: Set the value of a constant or variable defined in wp-config.php file a
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -80,7 +80,7 @@ Feature: Set the value of a constant or variable defined in wp-config.php file a
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}  --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -168,11 +168,11 @@ Feature: Set the value of a constant or variable defined in wp-config.php file a
       """
 
   @custom-config-file
-  Scenario: Updating a non-existent value  in wp-custom-config.php without --add
+  Scenario: Updating a non-existent value in wp-custom-config.php without --add
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}  --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -252,7 +252,7 @@ Feature: Set the value of a constant or variable defined in wp-config.php file a
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}  --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -314,19 +314,19 @@ Feature: Set the value of a constant or variable defined in wp-config.php file a
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}  --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
       """
 
-    When I run `wp config set SOME_NAME some_value --type=constant  --config-file='wp-custom-config.php'`
+    When I run `wp config set SOME_NAME some_value --type=constant --config-file='wp-custom-config.php'`
     Then STDOUT should be:
       """
       Success: Added the constant 'SOME_NAME' to the 'wp-custom-config.php' file with the value 'some_value'.
       """
 
-    When I run `wp config set SOME_NAME some_value --type=variable  --config-file='wp-custom-config.php'`
+    When I run `wp config set SOME_NAME some_value --type=variable --config-file='wp-custom-config.php'`
     Then STDOUT should be:
       """
       Success: Added the variable 'SOME_NAME' to the 'wp-custom-config.php' file with the value 'some_value'.

--- a/features/config-shuffle-salts.feature
+++ b/features/config-shuffle-salts.feature
@@ -24,7 +24,7 @@ Feature: Refresh the salts in the wp-config.php file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-salts=true --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --skip-salts=true --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.
@@ -131,7 +131,7 @@ Feature: Refresh the salts in the wp-config.php file
     Given an empty directory
     And WP files
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --config-file='wp-custom-config.php'`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --config-file='wp-custom-config.php'`
     Then STDOUT should contain:
       """
       Generated 'wp-custom-config.php' file.


### PR DESCRIPTION
- Provide `--skip-check` to `wp config create` everywhere
- Add a new dedicated test covering `--skip-check`
- Rename `wp core config` to `wp config create` in tests so it’s less confusing
- Remove some errant whitespace here in some commands

See #167