### PR TITLE
Add support for MySQL socket connection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "wp-cli/db-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^4.2.6"
+        "wp-cli/wp-cli-tests": "^4.2.7"
     },
     "config": {
         "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "wp-cli/db-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^4"
+        "wp-cli/wp-cli-tests": "^4.2.5"
     },
     "config": {
         "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "wp-cli/db-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^4.2.5"
+        "wp-cli/wp-cli-tests": "^4.2.6"
     },
     "config": {
         "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "wp-cli/db-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^4.2.7"
+        "wp-cli/wp-cli-tests": "^4.2.8"
     },
     "config": {
         "process-timeout": 7200,

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -160,14 +160,20 @@ Feature: Create a wp-config file
       Error: Database connection error
       """
 
+  @require-mysql
   Scenario: Configure with database credentials using socket path
-    Given an empty directory
-    And WP files
+    Given a WP install
 
-    When I try `wp config create {CORE_CONFIG_SETTINGS} --dbhost=/tmp/mysql.sock  --skip-check`
+    When I run `wp db query 'SELECT @@GLOBAL.SOCKET' --skip-column-names`
+    Then save STDOUT as {SOCKET}
+
+    When I run `rm wp-config.php`
+    Then the wp-config.php file should not exist
+
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --dbhost={SOCKET}`
     Then the wp-config.php file should contain:
       """
-      define( 'DB_HOST', '/tmp/mysql.sock' );
+      define( 'DB_HOST', '{SOCKET}' );
       """
 
   @require-php-7.0

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -162,13 +162,23 @@ Feature: Create a wp-config file
 
   @require-mysql
   Scenario: Configure with database credentials using socket path
-    Given a WP install
+    Given an empty directory
+    And WP files
+    And a find-socket.php file:
+      """
+      <?php
+      if ( file_exists( '/var/run/mysqld/mysqld.sock' ) ) {
+        echo '/var/run/mysqld/mysqld.sock';
+      } else if ( file_exists( '/tmp/mysql.sock' ) ) {
+        echo '/tmp/mysql.sock';
+      } else {
+        echo 'No socket found';
+        exit(1);
+      }
+      """
 
-    When I run `wp db query 'SELECT @@GLOBAL.SOCKET' --skip-column-names`
+    When I run `#!/usr/bin/env php find-socket.php`
     Then save STDOUT as {SOCKET}
-
-    When I run `rm wp-config.php`
-    Then the wp-config.php file should not exist
 
     When I run `wp config create {CORE_CONFIG_SETTINGS} --dbhost={SOCKET}`
     Then the wp-config.php file should contain:

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,7 +181,7 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
-    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost=localhost:{SOCKET}`
+    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='localhost:{SOCKET}'`
     Then the wp-config.php file should contain:
       """
       define( 'DB_HOST', 'localhost:{SOCKET}' );

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,10 +181,10 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
-    When I run `wp config create {CORE_CONFIG_SETTINGS} --dbhost={SOCKET}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --dbhost=localhost:{SOCKET}`
     Then the wp-config.php file should contain:
       """
-      define( 'DB_HOST', '{SOCKET}' );
+      define( 'DB_HOST', 'localhost:{SOCKET}' );
       """
 
   @require-php-7.0

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -167,16 +167,22 @@ Feature: Create a wp-config file
     And a find-socket.php file:
       """
       <?php
-      if ( file_exists( '/tmp/mysqld.sock' ) ) {
-        echo '/tmp/mysqld.sock';
-      } else if ( file_exists( '/var/run/mysqld/mysqld.sock' ) ) {
-        echo '/var/run/mysqld/mysqld.sock';
-      } else if ( file_exists( '/tmp/mysql.sock' ) ) {
-        echo '/tmp/mysql.sock';
-      } else {
-        echo 'No socket found';
-        exit(1);
+      $environment_socket = getenv( 'WP_CLI_TEST_DBSOCKET' );
+      $vendor_dir = \WP_CLI\Tests\Context\FeatureContext::get_vendor_dir();
+      $locations = [
+        $environment_socket,
+        "{$vendor_dir}/wp-cli/wp-cli-tests/utils/mapped_socket_folder/mysqld.sock",
+        '/var/run/mysqld/mysqld.sock',
+        '/tmp/mysql.sock',
+      ];
+      foreach ( $locations as $location ) {
+        if ( ! empty( $location ) && file_exists( $location ) ) {
+          echo $location;
+          exit(0);
+        }
       }
+      echo 'No socket found';
+      exit(1);
       """
 
     When I run `php find-socket.php`

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -190,16 +190,16 @@ Feature: Create a wp-config file
     When I run `chmod +x {RUN_DIR}/install-package-tests`
     Then STDERR should be empty
 
-    When I run `WP_CLI_TEST_DBHOST=127.0.0.1:{SOCKET} {RUN_DIR}/install-package-tests`
+    When I run `WP_CLI_TEST_DBHOST=localhost:{SOCKET} {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL
       """
 
-    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='127.0.0.1:{SOCKET}'`
+    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='localhost:{SOCKET}'`
     Then the wp-config.php file should contain:
       """
-      define( 'DB_HOST', '127.0.0.1:{SOCKET}' );
+      define( 'DB_HOST', 'localhost:{SOCKET}' );
       """
 
   @require-php-7.0

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -191,7 +191,7 @@ Feature: Create a wp-config file
     Then STDERR should be empty
 
     # We try to account for the warnings we get for passing the password on the command line.
-    When I try `WP_CLI_TEST_DBHOST='localhost:{SOCKET}' WP_CLI_TEST_DBROOTPASS='root' {RUN_DIR}/install-package-tests`
+    When I try `WP_CLI_TEST_DBHOST='localhost:{SOCKET}' {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -204,7 +204,7 @@ Feature: Create a wp-config file
     Then STDERR should be empty
 
     # We try to account for the warnings we get for passing the password on the command line.
-    When I try `MYSQL_HOST=localhost WP_CLI_TEST_DBHOST='localhost:{SOCKET}' {RUN_DIR}/install-package-tests`
+    When I try `MYSQL_HOST=localhost WP_CLI_TEST_DBHOST='localhost:{SOCKET}' WP_CLI_TEST_DBROOTPASS='root' {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -204,7 +204,7 @@ Feature: Create a wp-config file
     Then STDERR should be empty
 
     # We try to account for the warnings we get for passing the password on the command line.
-    When I try `WP_CLI_TEST_DBHOST='localhost:{SOCKET}' {RUN_DIR}/install-package-tests`
+    When I try `MYSQL_HOST='localhost:{SOCKET}' WP_CLI_TEST_DBHOST='localhost:{SOCKET}' {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -190,16 +190,16 @@ Feature: Create a wp-config file
     When I run `chmod +x {RUN_DIR}/install-package-tests`
     Then STDERR should be empty
 
-    When I run `WP_CLI_TEST_DBHOST=localhost:{SOCKET} {RUN_DIR}/install-package-tests`
+    When I run `WP_CLI_TEST_DBHOST=127.0.0.1:{SOCKET} {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL
       """
 
-    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='localhost:{SOCKET}'`
+    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='127.0.0.1:{SOCKET}'`
     Then the wp-config.php file should contain:
       """
-      define( 'DB_HOST', 'localhost:{SOCKET}' );
+      define( 'DB_HOST', '127.0.0.1:{SOCKET}' );
       """
 
   @require-php-7.0

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,7 +181,7 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
-    When I run `wp config create {CORE_CONFIG_SETTINGS} --dbhost=localhost:{SOCKET}`
+    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost=localhost:{SOCKET}`
     Then the wp-config.php file should contain:
       """
       define( 'DB_HOST', 'localhost:{SOCKET}' );

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -177,8 +177,9 @@ Feature: Create a wp-config file
       }
       """
 
-    When I run `#!/usr/bin/env php find-socket.php`
+    When I run `php find-socket.php`
     Then save STDOUT as {SOCKET}
+    And STDOUT should not be empty
 
     When I run `wp config create {CORE_CONFIG_SETTINGS} --dbhost={SOCKET}`
     Then the wp-config.php file should contain:

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -160,6 +160,17 @@ Feature: Create a wp-config file
       Error: Database connection error
       """
 
+  @require-mysql
+  Scenario: Configure with database credentials using socket path
+    Given an empty directory
+    And WP files
+
+    When I try `wp config create {CORE_CONFIG_SETTINGS} --dbhost=/tmp/mysql.sock`
+    Then the wp-config.php file should contain:
+      """
+      define( 'DB_HOST', '/tmp/mysql.sock' );
+      """
+
   @require-php-7.0
   Scenario: Configure with salts generated
     Given an empty directory

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,7 +181,7 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
-    When I run `WP_CLI_TEST_DBHOST={SOCKET} vendor/bin/install-package-tests`
+    When I run `WP_CLI_TEST_DBHOST={SOCKET} {RUN_DIR}/vendor/bin/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,6 +181,12 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
+    When I run `WP_CLI_TEST_DBHOST=localhost:{SOCKET} composer prepare-tests`
+    Then STDOUT should contain:
+      """
+      Detected MySQL
+      """
+
     When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='localhost:{SOCKET}'`
     Then the wp-config.php file should contain:
       """

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -168,10 +168,12 @@ Feature: Create a wp-config file
       """
       <?php
       // The WP_CLI_TEST_DBSOCKET variable can be set in the environment to
-      // override the default locations.
-      $environment_socket = getenv( 'WP_CLI_TEST_DBSOCKET' );
+      // override the default locations and will take precedence.
+      if ( ! empty( getenv( 'WP_CLI_TEST_DBSOCKET' ) ) ) {
+        echo getenv( 'WP_CLI_TEST_DBSOCKET' );
+        exit(0);
+      }
       $locations = [
-        $environment_socket,
         '/var/run/mysqld/mysqld.sock',
         '/tmp/mysql.sock',
       ];

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,16 +181,10 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
-    When I run `WP_CLI_TEST_DBHOST=localhost:{SOCKET} composer prepare-tests`
-    Then STDOUT should contain:
-      """
-      Detected MySQL
-      """
-
-    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='localhost:{SOCKET}'`
+    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='127.0.0.1:{SOCKET}'`
     Then the wp-config.php file should contain:
       """
-      define( 'DB_HOST', 'localhost:{SOCKET}' );
+      define( 'DB_HOST', '127.0.0.1:{SOCKET}' );
       """
 
   @require-php-7.0

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -190,7 +190,8 @@ Feature: Create a wp-config file
     When I run `chmod +x {RUN_DIR}/install-package-tests`
     Then STDERR should be empty
 
-    When I run `WP_CLI_TEST_DBHOST='localhost:{SOCKET}' WP_CLI_TEST_DBROOTPASS='root' {RUN_DIR}/install-package-tests`
+    # We try to account for the warnings we get for passing the password on the command line.
+    When I try `WP_CLI_TEST_DBHOST='localhost:{SOCKET}' WP_CLI_TEST_DBROOTPASS='root' {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,10 +181,10 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
-    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='127.0.0.1:{SOCKET}'`
+    When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='localhost:{SOCKET}'`
     Then the wp-config.php file should contain:
       """
-      define( 'DB_HOST', '127.0.0.1:{SOCKET}' );
+      define( 'DB_HOST', 'localhost:{SOCKET}' );
       """
 
   @require-php-7.0

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -168,10 +168,8 @@ Feature: Create a wp-config file
       """
       <?php
       $environment_socket = getenv( 'WP_CLI_TEST_DBSOCKET' );
-      $vendor_dir = \WP_CLI\Tests\Context\FeatureContext::get_vendor_dir();
       $locations = [
         $environment_socket,
-        "{$vendor_dir}/wp-cli/wp-cli-tests/utils/mapped_socket_folder/mysqld.sock",
         '/var/run/mysqld/mysqld.sock',
         '/tmp/mysql.sock',
       ];

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,7 +181,16 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
-    When I run `WP_CLI_TEST_DBHOST={SOCKET} {RUN_DIR}/vendor/bin/install-package-tests`
+    When I try `wget -O {RUN_DIR}/install-package-tests https://raw.githubusercontent.com/wp-cli/wp-cli-tests/main/bin/install-package-tests`
+    Then STDERR should contain:
+      """
+      install-package-tests' saved
+      """
+
+    When I run `chmod +x {RUN_DIR}/install-package-tests`
+    Then STDERR should be empty
+
+    When I run `WP_CLI_TEST_DBHOST={SOCKET} {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -204,7 +204,7 @@ Feature: Create a wp-config file
     Then STDERR should be empty
 
     # We try to account for the warnings we get for passing the password on the command line.
-    When I try `MYSQL_HOST='localhost:{SOCKET}' WP_CLI_TEST_DBHOST='localhost:{SOCKET}' {RUN_DIR}/install-package-tests`
+    When I try `MYSQL_HOST=localhost WP_CLI_TEST_DBHOST='localhost:{SOCKET}' {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -181,6 +181,12 @@ Feature: Create a wp-config file
     Then save STDOUT as {SOCKET}
     And STDOUT should not be empty
 
+    When I run `WP_CLI_TEST_DBHOST={SOCKET} vendor/bin/install-package-tests`
+    Then STDOUT should contain:
+      """
+      Detected MySQL
+      """
+
     When I run `wp config create --dbname='{DB_NAME}' --dbuser='{DB_USER}' --dbpass='{DB_PASSWORD}' --dbhost='localhost:{SOCKET}'`
     Then the wp-config.php file should contain:
       """

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -160,12 +160,11 @@ Feature: Create a wp-config file
       Error: Database connection error
       """
 
-  @require-mysql
   Scenario: Configure with database credentials using socket path
     Given an empty directory
     And WP files
 
-    When I try `wp config create {CORE_CONFIG_SETTINGS} --dbhost=/tmp/mysql.sock`
+    When I try `wp config create {CORE_CONFIG_SETTINGS} --dbhost=/tmp/mysql.sock  --skip-check`
     Then the wp-config.php file should contain:
       """
       define( 'DB_HOST', '/tmp/mysql.sock' );

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -167,7 +167,9 @@ Feature: Create a wp-config file
     And a find-socket.php file:
       """
       <?php
-      if ( file_exists( '/var/run/mysqld/mysqld.sock' ) ) {
+      if ( file_exists( '/tmp/mysqld.sock' ) ) {
+        echo '/tmp/mysqld.sock';
+      } else if ( file_exists( '/var/run/mysqld/mysqld.sock' ) ) {
         echo '/var/run/mysqld/mysqld.sock';
       } else if ( file_exists( '/tmp/mysql.sock' ) ) {
         echo '/tmp/mysql.sock';

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -190,7 +190,7 @@ Feature: Create a wp-config file
     When I run `chmod +x {RUN_DIR}/install-package-tests`
     Then STDERR should be empty
 
-    When I run `WP_CLI_TEST_DBHOST=localhost:{SOCKET} {RUN_DIR}/install-package-tests`
+    When I run `WP_CLI_TEST_DBHOST='localhost:{SOCKET}' WP_CLI_TEST_DBROOTPASS='root' {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -167,6 +167,8 @@ Feature: Create a wp-config file
     And a find-socket.php file:
       """
       <?php
+      // The WP_CLI_TEST_DBSOCKET variable can be set in the environment to
+      // override the default locations.
       $environment_socket = getenv( 'WP_CLI_TEST_DBSOCKET' );
       $locations = [
         $environment_socket,

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -190,7 +190,7 @@ Feature: Create a wp-config file
     When I run `chmod +x {RUN_DIR}/install-package-tests`
     Then STDERR should be empty
 
-    When I run `WP_CLI_TEST_DBHOST={SOCKET} {RUN_DIR}/install-package-tests`
+    When I run `WP_CLI_TEST_DBHOST=localhost:{SOCKET} {RUN_DIR}/install-package-tests`
     Then STDOUT should contain:
       """
       Detected MySQL

--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -173,7 +173,10 @@ Feature: Create a wp-config file
         echo getenv( 'WP_CLI_TEST_DBSOCKET' );
         exit(0);
       }
+      // From within Behat, the WP_CLI_TEST_DBSOCKET will be mapped to the internal
+      // DB_SOCKET variable, as Behat pushes a new environment context.
       $locations = [
+        '{DB_SOCKET}',
         '/var/run/mysqld/mysqld.sock',
         '/tmp/mysql.sock',
       ];

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -163,7 +163,13 @@ class Config_Command extends WP_CLI_Command {
 			$mysql = mysqli_init();
 			mysqli_report( MYSQLI_REPORT_STRICT );
 			try {
-				mysqli_real_connect( $mysql, $assoc_args['dbhost'], $assoc_args['dbuser'], $assoc_args['dbpass'] );
+				if ( file_exists($assoc_args['dbhost']) ) {
+					// If dbhost is a path to a socket
+					mysqli_real_connect( $mysql, null, $assoc_args['dbuser'], $assoc_args['dbpass'], null, null, $assoc_args['dbhost'] );
+				} else {
+					// If dbhost is a hostname or IP address
+					mysqli_real_connect( $mysql, $assoc_args['dbhost'], $assoc_args['dbuser'], $assoc_args['dbpass'] );
+				}
 			} catch ( mysqli_sql_exception $exception ) {
 				WP_CLI::error( 'Database connection error (' . $exception->getCode() . ') ' . $exception->getMessage() );
 			}

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -163,7 +163,7 @@ class Config_Command extends WP_CLI_Command {
 			$mysql = mysqli_init();
 			mysqli_report( MYSQLI_REPORT_STRICT );
 			try {
-				if ( file_exists($assoc_args['dbhost']) ) {
+				if ( file_exists( $assoc_args['dbhost'] ) ) {
 					// If dbhost is a path to a socket
 					mysqli_real_connect( $mysql, null, $assoc_args['dbuser'], $assoc_args['dbpass'], null, null, $assoc_args['dbhost'] );
 				} else {

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -163,12 +163,21 @@ class Config_Command extends WP_CLI_Command {
 			$mysql = mysqli_init();
 			mysqli_report( MYSQLI_REPORT_STRICT );
 			try {
-				if ( file_exists( $assoc_args['dbhost'] ) ) {
+				// Accept similar format to one used by parse_db_host() e.g. 'localhost:/tmp/mysql.sock'
+				$socket     = '';
+				$host       = $assoc_args['dbhost'];
+				$socket_pos = strpos( $host, ':/' );
+				if ( false !== $socket_pos ) {
+					$socket = substr( $host, $socket_pos + 1 );
+					$host   = substr( $host, 0, $socket_pos );
+				}
+
+				if ( file_exists( $socket ) ) {
 					// If dbhost is a path to a socket
-					mysqli_real_connect( $mysql, null, $assoc_args['dbuser'], $assoc_args['dbpass'], null, null, $assoc_args['dbhost'] );
+					mysqli_real_connect( $mysql, null, $assoc_args['dbuser'], $assoc_args['dbpass'], null, null, $socket );
 				} else {
 					// If dbhost is a hostname or IP address
-					mysqli_real_connect( $mysql, $assoc_args['dbhost'], $assoc_args['dbuser'], $assoc_args['dbpass'] );
+					mysqli_real_connect( $mysql, $host, $assoc_args['dbuser'], $assoc_args['dbpass'] );
 				}
 			} catch ( mysqli_sql_exception $exception ) {
 				WP_CLI::error( 'Database connection error (' . $exception->getCode() . ') ' . $exception->getMessage() );


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Related https://github.com/wp-cli/wp-cli/issues/5859

In this diff, I propose to add support for MySQL socket connection to the `wp config create` command.

I used the approach proposed by @aonsyed under https://github.com/wp-cli/config-command/issues/169

**Testing steps:**

1. Start MySQL/MariaDB, download WordPress and unpack it 
2. Test MySQL socket connection e.g.
```
mysql -S /tmp/mysql.sock
```
3. Create a database user
4. Run command
```
vendor/bin/wp config create --dbname=dbname --dbuser=dbuser --dbpass=somevalue --dbprefix=wp_ --url=site.com --dbhost=localhost:/tmp/mysql.sock --allow-root --skip-themes --skip-packages --skip-plugins --path=/Sites/wordpress-root
```
5. Confirm the success message:
> Success: Generated 'wp-config.php' file.
6. Check if the `wp-config.php` file was created and confirm that it has a socket configured in place of dbhost