### PR TITLE
Fix incorrect message shuffling salt in PHP 5.6

### DIFF
--- a/features/config-shuffle-salts.feature
+++ b/features/config-shuffle-salts.feature
@@ -338,3 +338,17 @@ Feature: Refresh the salts in the wp-config.php file
     """
     define( 'NEW_KEY'
     """
+
+  @less-than-php-7.0
+  Scenario: Shuffling salts duplicate warnings on PHP < 7.0
+    Given a WP install
+    When I try `wp config shuffle-salts WP_CACHE_KEY_SALT NONCE_SALT`
+    Then STDERR should contain:
+    """
+    Warning: Could not shuffle the unknown key 'WP_CACHE_KEY_SALT'.
+    """
+    And STDERR should not contain:
+    """
+    Warning: Could not shuffle the unknown key 'WP_CACHE_KEY_SALT'.
+    Warning: Could not shuffle the unknown key 'WP_CACHE_KEY_SALT'.
+    """

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -889,11 +889,12 @@ class Config_Command extends WP_CLI_Command {
 
 		try {
 			foreach ( $keys as $key ) {
+				$unique_key = self::unique_key();
 				if ( ! $force && ! in_array( $key, self::DEFAULT_SALT_CONSTANTS, true ) ) {
 					WP_CLI::warning( "Could not shuffle the unknown key '{$key}'." );
 					continue;
 				}
-				$secret_keys[ $key ] = trim( self::unique_key() );
+				$secret_keys[ $key ] = trim( $unique_key );
 			}
 		} catch ( Exception $ex ) {
 			foreach ( $keys as $key ) {


### PR DESCRIPTION
Fixes https://github.com/wp-cli/config-command/issues/175