### PR TITLE
Improve messaging when shuffling salts

### DIFF
--- a/features/config-shuffle-salts.feature
+++ b/features/config-shuffle-salts.feature
@@ -295,7 +295,7 @@ Feature: Refresh the salts in the wp-config.php file
     When I try `wp config shuffle-salts AUTH_KEY NEW_KEY`
     Then STDOUT should contain:
     """
-    Shuffled 2 of 2 salts.
+    Shuffled 1 of 2 salts (1 skipped).
     """
     And STDERR should contain:
     """

--- a/features/config-shuffle-salts.feature
+++ b/features/config-shuffle-salts.feature
@@ -111,7 +111,7 @@ Feature: Refresh the salts in the wp-config.php file
     When I run `wp config shuffle-salts AUTH_KEY NONCE_KEY`
     Then STDOUT should contain:
     """
-    Shuffled the salt keys.
+    Shuffled 2 of 2 salts.
     """
     And the wp-config.php file should not contain:
     """
@@ -199,7 +199,7 @@ Feature: Refresh the salts in the wp-config.php file
     When I try `wp config shuffle-salts AUTH_KEY NEW_KEY`
     Then STDOUT should contain:
     """
-    Shuffled the salt keys.
+    Shuffled 1 of 2 salts (1 skipped).
     """
     And STDERR should contain:
     """
@@ -224,7 +224,7 @@ Feature: Refresh the salts in the wp-config.php file
     When I run `wp config shuffle-salts AUTH_KEY NEW_KEY --force`
     Then STDOUT should contain:
     """
-    Shuffled the salt keys.
+    Shuffled 2 of 2 salts.
     """
     And the wp-config.php file should not contain:
     """
@@ -247,7 +247,7 @@ Feature: Refresh the salts in the wp-config.php file
     When I run `wp config shuffle-salts AUTH_KEY NEW_KEY --force`
     Then STDOUT should contain:
     """
-    Shuffled the salt keys.
+    Shuffled 2 of 2 salts.
     """
     And the wp-config.php file should not contain:
     """
@@ -295,7 +295,7 @@ Feature: Refresh the salts in the wp-config.php file
     When I try `wp config shuffle-salts AUTH_KEY NEW_KEY`
     Then STDOUT should contain:
     """
-    Shuffled the salt keys.
+    Shuffled 2 of 2 salts.
     """
     And STDERR should contain:
     """
@@ -320,7 +320,7 @@ Feature: Refresh the salts in the wp-config.php file
     When I try `wp config shuffle-salts AUTH_KEY NEW_KEY --force`
     Then STDOUT should contain:
     """
-    Shuffled the salt keys.
+    Shuffled 1 of 2 salts (1 skipped).
     """
     And STDERR should contain:
     """

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -880,7 +880,7 @@ class Config_Command extends WP_CLI_Command {
 		$keys  = $args;
 		$force = Utils\get_flag_value( $assoc_args, 'force', false );
 
-		$is_default_keys = ( empty( $keys ) ) ? true : false;
+		$has_keys = ( ! empty( $keys ) ) ? true : false;
 
 		if ( empty( $keys ) ) {
 			$keys = self::DEFAULT_SALT_CONSTANTS;
@@ -930,18 +930,22 @@ class Config_Command extends WP_CLI_Command {
 		try {
 			$config_transformer = new WPConfigTransformer( $path );
 			foreach ( $secret_keys as $key => $value ) {
-				$config_transformer->update( 'constant', $key, (string) $value );
-				++$successes;
+				$is_updated = $config_transformer->update( 'constant', $key, (string) $value );
+				if ( $is_updated ) {
+					++$successes;
+				} else {
+					++$errors;
+				}
 			}
 		} catch ( Exception $exception ) {
 			$wp_config_file_name = basename( $path );
 			WP_CLI::error( "Could not process the '{$wp_config_file_name}' transformation.\nReason: {$exception->getMessage()}" );
 		}
 
-		if ( $is_default_keys ) {
-			WP_CLI::success( 'Shuffled the salt keys.' );
-		} else {
+		if ( $has_keys ) {
 			Utils\report_batch_operation_results( 'salt', 'shuffle', count( $keys ), $successes, $errors, $skipped );
+		} else {
+			WP_CLI::success( 'Shuffled the salt keys.' );
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/config-command/issues/173

* If no keys are passed, original success message `Shuffled the salt keys.` will be displayed.
* `Utils\report_batch_operation_results()` is used to display message when keys are passed.