### PR TITLE
Refactor config create command

### DIFF
--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -293,3 +293,12 @@ Feature: Create a wp-config file
       PasswordWith'SingleQuotes'
       """
 
+  Scenario: Correct config file is generated when database password has double quote in it
+    Given an empty directory
+    And WP files
+
+    When I run `wp config create --skip-check --dbname=somedb --dbuser=someuser --dbpass='p@(ss){w0r?d><}"!With"DoubleQuotes'`
+    Then the wp-config.php file should contain:
+      """
+      define( 'DB_PASSWORD', 'p@(ss){w0r?d><}"!With"DoubleQuotes' )
+      """

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -239,6 +239,12 @@ class Config_Command extends WP_CLI_Command {
 			'config-file' => rtrim( ABSPATH, '/\\' ) . '/wp-config.php',
 		];
 
+		if ( Utils\wp_version_compare( '4.0', '<' ) ) {
+			$defaults['add-wplang'] = true;
+		} else {
+			$defaults['add-wplang'] = false;
+		}
+
 		if ( ! Utils\get_flag_value( $assoc_args, 'skip-salts' ) ) {
 			try {
 				$defaults['keys-and-salts']    = true;
@@ -259,19 +265,14 @@ class Config_Command extends WP_CLI_Command {
 			}
 		}
 
-		if ( Utils\wp_version_compare( '4.0', '<' ) ) {
-			$defaults['add-wplang'] = true;
-		} else {
-			$defaults['add-wplang'] = false;
-		}
-
 		$path = $defaults['config-file'];
 		if ( ! empty( $assoc_args['config-file'] ) ) {
 			$path = $assoc_args['config-file'];
 		}
 
-		if ( ! empty( $assoc_args['extra-php'] ) ) {
-			$defaults['extra-php'] = $this->escape_config_value( 'extra-php', $assoc_args['extra-php'] );
+		if ( Utils\get_flag_value( $assoc_args, 'extra-php' ) === true ) {
+			// 'extra-php' from STDIN is retrieved.
+			$defaults['extra-php'] = file_get_contents( 'php://stdin' );
 		}
 
 		$command_root = Utils\phar_safe_path( dirname( __DIR__ ) );
@@ -286,12 +287,6 @@ class Config_Command extends WP_CLI_Command {
 		}
 
 		$assoc_args = array_merge( $defaults, $assoc_args );
-
-		// 'extra-php' from STDIN is retrieved after escaping to avoid breaking
-		// the PHP code.
-		if ( Utils\get_flag_value( $assoc_args, 'extra-php' ) === true ) {
-			$assoc_args['extra-php'] = file_get_contents( 'php://stdin' );
-		}
 
 		$options = [
 			'raw'       => false,

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -340,7 +340,7 @@ class Config_Command extends WP_CLI_Command {
 				}
 			}
 		} catch ( Exception $exception ) {
-			//Remove the default moustache wp-config.php template file.
+			// Remove the default moustache wp-config.php template file.
 			if ( file_exists( $assoc_args['config-file'] ) ) {
 				unlink( $path );
 			}


### PR DESCRIPTION
Fixes: https://github.com/wp-cli/config-command/issues/94
Fixes https://github.com/wp-cli/config-command/issues/180

Refactored code for wp config create command renders the default moustache template with default values along with the `extra-php` input if specified. And further it uses update method from WPConfigTransformer class to set the config values for all provided arguments.

