### PR TITLE
Replace boolean value of config variables to literal string when showing to the user

### DIFF
--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -534,7 +534,7 @@ class Config_Command extends WP_CLI_Command {
 	public function is_true( $args, $assoc_args ) {
 		$value = $this->get_value( $assoc_args, $args );
 
-		if ( boolval( $value ) ) {
+		if ( boolval( $value ) && 'false' !== $value ) { // Second condition is needed because we have literal "false" as string and boolval('false') is true.
 			WP_CLI::halt( 0 );
 		}
 		WP_CLI::halt( 1 );
@@ -578,7 +578,14 @@ class Config_Command extends WP_CLI_Command {
 			];
 		}
 
-		return array_merge( $wp_config_vars, $wp_config_constants, $wp_config_includes_array );
+		$merged_vars = array_merge( $wp_config_vars, $wp_config_constants, $wp_config_includes_array );
+		// Modify boolean values for easier handling.
+		foreach ( $merged_vars as $index => $var ) {
+			if ( 'boolean' === gettype( $var['value'] ) ) {
+				$merged_vars[ $index ]['value'] = $var['value'] ? 'true' : 'false';
+			}
+		}
+		return $merged_vars;
 	}
 
 	/**


### PR DESCRIPTION
This pull request fixes following issue
- #165 

I refactored the code to return the string representation of a boolean value (i.e., 'true' or 'false'), which is easier to display to the user. Previously, when the variable's value was true, it would render as '1', and blank when false. Using strings allows us to provide clearer guidance to the user regarding which value is true and which is false.