### PR TITLE
Don't require file to be writable for config has

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "wp-cli/wp-cli": "^2.5",
-        "wp-cli/wp-config-transformer": "^1.2.1"
+        "wp-cli/wp-config-transformer": "^1.4.0"
     },
     "require-dev": {
         "wp-cli/db-command": "^1.3 || ^2",

--- a/features/config-has.feature
+++ b/features/config-has.feature
@@ -15,6 +15,14 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
     Then STDOUT should be empty
     And the return code should be 0
 
+  Scenario: Check for the existance of an existing wp-config.php constant in a read-only file system
+    Given a WP install
+
+    When I run `chmod -w wp-config.php`
+    And I try `wp config has DB_NAME`
+    Then STDOUT should be empty
+    And the return code should be 0
+
   @custom-config-file
   Scenario: Check the existence of an existing wp-custom-config.php constant or variable
     Given an empty directory

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -818,7 +818,7 @@ class Config_Command extends WP_CLI_Command {
 		$type                = Utils\get_flag_value( $assoc_args, 'type' );
 
 		try {
-			$config_transformer = new WPConfigTransformer( $path );
+			$config_transformer = new WPConfigTransformer( $path, true );
 
 			switch ( $type ) {
 				case 'all':


### PR DESCRIPTION
Allows `config has` to work with read-only filesystems.

Requires https://github.com/wp-cli/wp-config-transformer/pull/54

Fixes #184 

Part of https://github.com/wp-cli/wp-cli/issues/5985