### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "wp-cli/wp-cli": "^2.5",
+        "wp-cli/wp-cli": "^2.12",
         "wp-cli/wp-config-transformer": "^1.4.0"
     },
     "require-dev": {


### PR DESCRIPTION
For improved PHP 8.4 compatibility.