### PR TITLE
PHPStan: Don't look in wp-cli-tests folder

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,6 @@ parameters:
     - config-command.php
   scanDirectories:
     - vendor/wp-cli/wp-cli/php
-    - vendor/wp-cli/wp-cli-tests
   scanFiles:
     - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
   treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
This folder will also have a vendor folder and PHPStan will try and read every file in there, likely running out of memory eventually:

```
isla@Mac ~/source/wp-cli-dev/config-command (phpstan-config-fix|u=) $ composer phpstan
Note: Using configuration file /Users/isla/source/wp-cli-dev/config-command/phpstan.neon.dist.
PHP Fatal error:  Allowed memory size of 2147483648 bytes exhausted (tried to allocate 20480 bytes) in phar:///Users/isla/source/wp-cli-dev/vendor/phpstan/phpstan/phpst
an.phar/vendor/symfony/finder/SplFileInfo.php on line 29
Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 20480 bytes) in phar:///Users/isla/source/wp-cli-dev/vendor/phpstan/phpstan/phpstan.ph
ar/vendor/symfony/finder/SplFileInfo.php on line 29

PHPStan process crashed because it reached configured PHP memory limit: 2048M
Increase your memory limit in php.ini or run PHPStan with --memory-limit CLI option.
Script run-phpstan-tests handling the phpstan event returned with error code 255
```