### PR TITLE
Add Behat test for `config has` after concatenation assignment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,9 @@
             "homepage": "https://www.alainschlesser.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/wp-cli/wp-config-transformer"
-        }
-    ],
     "require": {
         "wp-cli/wp-cli": "^2.13",
-        "wp-cli/wp-config-transformer": "dev-main"
+        "wp-cli/wp-config-transformer": "^1.4.0"
     },
     "require-dev": {
         "wp-cli/db-command": "^1.3 || ^2",

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,15 @@
             "homepage": "https://www.alainschlesser.com"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/wp-cli/wp-config-transformer"
+        }
+    ],
     "require": {
         "wp-cli/wp-cli": "^2.13",
-        "wp-cli/wp-config-transformer": "^1.4.0"
+        "wp-cli/wp-config-transformer": "dev-main"
     },
     "require-dev": {
         "wp-cli/db-command": "^1.3 || ^2",

--- a/features/config-has.feature
+++ b/features/config-has.feature
@@ -170,3 +170,24 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
       """
       Error: Found both a constant and a variable 'SOME_NAME' in the 'wp-custom-config.php' file. Use --type=<type> to disambiguate.
       """
+
+  Scenario: Find variable after a concatenation assignment
+    Given a WP install
+    And a wp-config.php file:
+      """
+      $do_redirect = 'https://example.com' . $_SERVER['REQUEST_URI'];
+      $table_prefix = 'wp_';
+      define( 'DB_NAME', 'wp' );
+      """
+
+    When I run `wp config has table_prefix --type=variable`
+    Then STDOUT should be empty
+    And the return code should be 0
+
+    When I run `wp config has DB_NAME --type=constant`
+    Then STDOUT should be empty
+    And the return code should be 0
+
+    When I run `wp config has do_redirect --type=variable`
+    Then STDOUT should be empty
+    And the return code should be 0

--- a/features/config-has.feature
+++ b/features/config-has.feature
@@ -171,23 +171,41 @@ Feature: Check whether the wp-config.php file or the wp-custom-config.php file h
       Error: Found both a constant and a variable 'SOME_NAME' in the 'wp-custom-config.php' file. Use --type=<type> to disambiguate.
       """
 
-  Scenario: Find variable after a concatenation assignment
-    Given a WP install
+  Scenario Outline: Find constants and variables in a config with complex expressions
+    Given an empty directory
+    And a wp-includes/version.php file:
+      """
+      <?php $wp_version = '6.3';
+      """
     And a wp-config.php file:
       """
+      <?php
       $do_redirect = 'https://example.com' . $_SERVER['REQUEST_URI'];
       $table_prefix = 'wp_';
       define( 'DB_NAME', 'wp' );
+      define( 'CUSTOM_CSS', 'body {
+        color: red;
+      }' );
+      $after_multiline = 'found';
+      $long_url = 'https://example.com'
+        . '/path';
+      define( 'ALLOWED_HOSTS', array(
+        'example.com',
+      ) );
+      $after_array_define = 'found';
       """
 
-    When I run `wp config has table_prefix --type=variable`
+    When I run `wp config has <name> --type=<type>`
     Then STDOUT should be empty
     And the return code should be 0
 
-    When I run `wp config has DB_NAME --type=constant`
-    Then STDOUT should be empty
-    And the return code should be 0
-
-    When I run `wp config has do_redirect --type=variable`
-    Then STDOUT should be empty
-    And the return code should be 0
+    Examples:
+      | name              | type     | description                              |
+      | do_redirect       | variable | concatenation expression itself          |
+      | table_prefix      | variable | variable after concatenation             |
+      | DB_NAME           | constant | constant after concatenation variable    |
+      | CUSTOM_CSS        | constant | constant with multiline string value     |
+      | after_multiline   | variable | variable after multiline string value    |
+      | long_url          | variable | multiline concatenation variable         |
+      | ALLOWED_HOSTS     | constant | constant with multiline raw value        |
+      | after_array_define | variable | variable after multiline raw define     |


### PR DESCRIPTION
## Summary

- Adds a behat scenario to `config-has.feature` that verifies `wp config has` finds variables and constants when the wp-config.php contains a variable assignment with string concatenation (e.g. `$x = 'foo' . $bar;`)

Depends on wp-cli/wp-config-transformer#64

## Dependency note

wp-cli/wp-config-transformer#64 is now merged. `composer.json` temporarily points at `dev-main` via a VCS repository entry so CI runs against the fixed code. Once a release of `wp-config-transformer` is cut, this PR will be updated to pin to that version and the `repositories` override removed.