### PR TITLE
Make --dbname and --dbuser optional when SQLite is active

### DIFF
--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -290,6 +290,33 @@ Feature: Create a wp-config file
     Then the return code should be 0
     And the subdir/wp-config.php file should exist
 
+  @require-sqlite
+  Scenario: Configure without --dbname and --dbuser when SQLite integration is active
+    Given a WP install
+    When I run `rm wp-config.php`
+    When I run `wp config create --skip-salts`
+    Then the return code should be 0
+    And STDOUT should contain:
+      """
+      Generated 'wp-config.php' file.
+      """
+
+  @skip-sqlite
+  Scenario: Error when --dbname and --dbuser are missing without SQLite
+    Given an empty directory
+    And WP files
+
+    When I try `wp config create --skip-check --skip-salts`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      missing --dbname parameter
+      """
+    And STDERR should contain:
+      """
+      missing --dbuser parameter
+      """
+
   @require-mysql @require-mysql-5.7
   Scenario: Configure with required SSL connection
     Given an empty directory

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -225,10 +225,10 @@ class Config_Command extends WP_CLI_Command {
 		if ( ! $is_sqlite ) {
 			$errors = [];
 			if ( ! isset( $assoc_args['dbname'] ) ) {
-				$errors[] = 'missing --dbname parameter (Set the database name.)';
+				$errors[] = 'missing --dbname parameter';
 			}
 			if ( ! isset( $assoc_args['dbuser'] ) ) {
-				$errors[] = 'missing --dbuser parameter (Set the database user.)';
+				$errors[] = 'missing --dbuser parameter';
 			}
 			if ( ! empty( $errors ) ) {
 				WP_CLI::error(
@@ -1531,7 +1531,7 @@ class Config_Command extends WP_CLI_Command {
 	 * @return bool
 	 */
 	private static function is_sqlite_integration_active() {
-		$wp_content_dir = defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : ABSPATH . 'wp-content';
+		$wp_content_dir = defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : rtrim( ABSPATH, '/\\' ) . '/wp-content';
 		$db_dropin_path = $wp_content_dir . '/db.php';
 
 		if ( ! is_readable( $db_dropin_path ) ) {

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -120,10 +120,10 @@ class Config_Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * --dbname=<dbname>
+	 * [--dbname=<dbname>]
 	 * : Set the database name.
 	 *
-	 * --dbuser=<dbuser>
+	 * [--dbuser=<dbuser>]
 	 * : Set the database user.
 	 *
 	 * [--dbpass=<dbpass>]
@@ -219,6 +219,24 @@ class Config_Command extends WP_CLI_Command {
 			'ssl'         => false,
 		];
 		$assoc_args = array_merge( $defaults, $assoc_args );
+
+		$is_sqlite = self::is_sqlite_integration_active();
+
+		if ( ! $is_sqlite ) {
+			$errors = [];
+			if ( ! isset( $assoc_args['dbname'] ) ) {
+				$errors[] = 'missing --dbname parameter (Set the database name.)';
+			}
+			if ( ! isset( $assoc_args['dbuser'] ) ) {
+				$errors[] = 'missing --dbuser parameter (Set the database user.)';
+			}
+			if ( ! empty( $errors ) ) {
+				WP_CLI::error(
+					'Parameter errors:' . "\n " . implode( "\n ", $errors )
+				);
+			}
+		}
+
 		if ( empty( $assoc_args['dbprefix'] ) ) {
 			WP_CLI::error( '--dbprefix cannot be empty' );
 		}
@@ -228,7 +246,7 @@ class Config_Command extends WP_CLI_Command {
 
 		// Check DB connection. To make command more portable, we are not using MySQL CLI and using
 		// mysqli directly instead, as $wpdb is not accessible in this context.
-		if ( ! Utils\get_flag_value( $assoc_args, 'skip-check' ) ) {
+		if ( ! $is_sqlite && ! Utils\get_flag_value( $assoc_args, 'skip-check' ) ) {
 			// phpcs:disable WordPress.DB.RestrictedFunctions
 			$mysql = mysqli_init();
 
@@ -1505,5 +1523,23 @@ class Config_Command extends WP_CLI_Command {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Check if the SQLite integration drop-in is active.
+	 *
+	 * @return bool
+	 */
+	private static function is_sqlite_integration_active() {
+		$wp_content_dir = defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : ABSPATH . 'wp-content';
+		$db_dropin_path = $wp_content_dir . '/db.php';
+
+		if ( ! is_readable( $db_dropin_path ) ) {
+			return false;
+		}
+
+		$contents = file_get_contents( $db_dropin_path );
+
+		return false !== $contents && false !== strpos( $contents, 'SQLITE_DB_DROPIN_VERSION' );
 	}
 }


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
`wp config create` requires `--dbname` and `--dbuser` even when the SQLite integration plugin is active. SQLite doesn't use these parameters, so users are forced to pass dummy MySQL credentials to create a wp-config.php for a SQLite-backed site.

Addresses the enhancement suggested by @mrsdizzie in https://github.com/wp-cli/config-command/issues/167#issuecomment-1779951710.

Also incorporates all review feedback from #219 (batched error messages, `is_readable()` guard, `isset()` instead of `empty()`).

## Changes

- **Synopsis**: `--dbname` and `--dbuser` are now optional (`[--dbname=<dbname>]`, `[--dbuser=<dbuser>]`)
- **SQLite detection**: New `is_sqlite_integration_active()` method scans `wp-content/db.php` for `SQLITE_DB_DROPIN_VERSION`, matching the approach used by `DB_Command_SQLite::is_sqlite()`
- **Validation**: When SQLite is not detected, missing `--dbname`/`--dbuser` still produces an error with both parameters reported in a single message
- **MySQLi check**: Skipped entirely when SQLite is detected

## Test coverage

- New `@require-sqlite` scenario: verifies `wp config create --skip-salts` succeeds without `--dbname`/`--dbuser` when the SQLite drop-in is present
- New `@skip-sqlite` scenario: verifies the error message when both parameters are missing on MySQL/MariaDB

Fixes #167

--

Related https://github.com/wp-cli/wp-cli/issues/6295
