### PR TITLE
Modernize deprecated syntax in Behat tests

### DIFF
--- a/features/config-create.feature
+++ b/features/config-create.feature
@@ -126,12 +126,12 @@ Feature: Create a wp-config file
       define( 'AUTH_SALT',
       """
 
-  Scenario: wp core config uses parameters from wp-cli.yml
+  Scenario: wp config create uses parameters from wp-cli.yml
     Given an empty directory
     And WP files
     And a wp-cli.yml file:
       """
-      core config:
+      config create:
         dbname: wordpress
         dbuser: root
         extra-php: |
@@ -139,7 +139,7 @@ Feature: Create a wp-config file
           define( 'WP_POST_REVISIONS', 50 );
       """
 
-    When I run `wp core config --skip-check`
+    When I run `wp config create --skip-check`
     Then the wp-config.php file should contain:
       """
       define( 'DB_NAME', 'wordpress' )


### PR DESCRIPTION
## What

Updates the Behat tests to use the current command syntax instead of forms deprecated by wp-cli/wp-cli#6356.

## Why

The framework now emits a deprecation warning to STDERR when it rewrites these legacy forms. This breaks `When I run` steps, which expect STDERR to remain empty.

## Tests

- `composer test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated configuration creation coverage to verify that `wp config create --skip-check` reads database settings and additional PHP configuration from `wp-cli.yml`.
  - Confirmed generated `wp-config.php` includes the expected database values and post-revision setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->